### PR TITLE
Add support for parsing ADTs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,20 @@ Let bindings:
     id = x -> x
     id
 
+Algebraic data types:
+
+    bool = data (true, false)
+
+    maybe = data (none, just x)
+
+    tree = data (
+      empty
+      left x
+      right x
+    )
+
+    tree
+
 Grouping:
 
     f -> g -> x -> f (g x)

--- a/include/ast.h
+++ b/include/ast.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 namespace poi {
 
@@ -24,7 +25,6 @@ namespace poi {
     std::unordered_set<size_t> free_variables;
 
     virtual ~Term();
-    virtual std::unique_ptr<Term> clone() = 0;
     virtual std::string show() = 0;
     virtual std::shared_ptr<poi::Value> eval(
       std::shared_ptr<poi::Term> term,
@@ -41,7 +41,6 @@ namespace poi {
       std::shared_ptr<std::string> name,
       size_t variable_id
     );
-    std::unique_ptr<Term> clone() override;
     std::string show() override;
     std::shared_ptr<poi::Value> eval(
       std::shared_ptr<poi::Term> term,
@@ -60,7 +59,6 @@ namespace poi {
       size_t variable_id,
       std::shared_ptr<poi::Term> body
     );
-    std::unique_ptr<Term> clone() override;
     std::string show() override;
     std::shared_ptr<poi::Value> eval(
       std::shared_ptr<poi::Term> term,
@@ -77,7 +75,6 @@ namespace poi {
       std::shared_ptr<poi::Term> abstraction,
       std::shared_ptr<poi::Term> operand
     );
-    std::unique_ptr<Term> clone() override;
     std::string show() override;
     std::shared_ptr<poi::Value> eval(
       std::shared_ptr<poi::Term> term,
@@ -98,7 +95,36 @@ namespace poi {
       std::shared_ptr<poi::Term> definition,
       std::shared_ptr<poi::Term> body
     );
-    std::unique_ptr<Term> clone() override;
+    std::string show() override;
+    std::shared_ptr<poi::Value> eval(
+      std::shared_ptr<poi::Term> term,
+      std::unordered_map<size_t, std::shared_ptr<poi::Value>> &environment
+    ) override;
+  };
+
+  class DataConstructor {
+  public:
+    std::shared_ptr<std::string> name;
+    size_t name_id;
+    std::shared_ptr<std::vector<std::shared_ptr<std::string>>> params;
+    std::shared_ptr<std::vector<size_t>> param_ids;
+
+    explicit DataConstructor(
+      std::shared_ptr<std::string> name,
+      size_t name_id,
+      std::shared_ptr<std::vector<std::shared_ptr<std::string>>> params,
+      std::shared_ptr<std::vector<size_t>> param_ids
+    );
+    std::string show();
+  };
+
+  class DataType : public Term {
+  public:
+    std::shared_ptr<std::vector<poi::DataConstructor>> constructors;
+
+    explicit DataType(
+      std::shared_ptr<std::vector<poi::DataConstructor>> constructors
+    );
     std::string show() override;
     std::shared_ptr<poi::Value> eval(
       std::shared_ptr<poi::Term> term,
@@ -111,7 +137,6 @@ namespace poi {
     std::shared_ptr<poi::Term> body;
 
     explicit Group(std::shared_ptr<poi::Term> body);
-    std::unique_ptr<Term> clone() override;
     std::string show() override;
     std::shared_ptr<poi::Value> eval(
       std::shared_ptr<poi::Term> term,

--- a/include/token.h
+++ b/include/token.h
@@ -12,6 +12,7 @@ namespace poi {
 
   enum class TokenType {
     ARROW,
+    DATA,
     EQUALS,
     IDENTIFIER,
     LEFT_PAREN,
@@ -21,6 +22,7 @@ namespace poi {
 
   const char * const TokenTypeName[] = {
     "ARROW",
+    "DATA",
     "EQUALS",
     "IDENTIFIER",
     "LEFT_PAREN",

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -18,10 +18,6 @@ poi::Variable::Variable(
 ) : name(name), variable_id(variable_id) {
 }
 
-std::unique_ptr<poi::Term> poi::Variable::clone() {
-  return std::unique_ptr<Term>(new Variable(name, variable_id));
-}
-
 std::string poi::Variable::show() {
   return *name;
 }
@@ -42,18 +38,6 @@ poi::Abstraction::Abstraction(
   size_t variable_id,
   std::shared_ptr<poi::Term> body
 ) : variable(variable), variable_id(variable_id), body(body) {
-}
-
-std::unique_ptr<poi::Term> poi::Abstraction::clone() {
-  return std::unique_ptr<Term>(new Abstraction(
-    variable,
-    variable_id,
-    std::shared_ptr<Term>(
-      body ?
-        static_cast<Term*>(body->clone().release()) :
-        nullptr
-    )
-  ));
 }
 
 std::string poi::Abstraction::show() {
@@ -87,20 +71,6 @@ poi::Application::Application(
   std::shared_ptr<poi::Term> abstraction,
   std::shared_ptr<poi::Term> operand
 ) : abstraction(abstraction), operand(operand) {
-}
-
-std::unique_ptr<poi::Term> poi::Application::clone() {
-  return std::unique_ptr<Term>(new Application(
-    std::shared_ptr<Term>(
-      abstraction ?
-        static_cast<Term*>(abstraction->clone().release()) :
-        nullptr
-    ), std::shared_ptr<Term>(
-      operand ?
-        static_cast<Term*>(operand->clone().release()) :
-        nullptr
-    )
-  ));
 }
 
 std::string poi::Application::show() {
@@ -160,23 +130,6 @@ poi::Let::Let(
   body(body) {
 }
 
-std::unique_ptr<poi::Term> poi::Let::clone() {
-  return std::unique_ptr<Term>(new Let(
-    variable,
-    variable_id,
-    std::shared_ptr<Term>(
-      definition ?
-        static_cast<Term*>(definition->clone().release()) :
-        nullptr
-    ),
-    std::shared_ptr<Term>(
-      body ?
-        static_cast<Term*>(body->clone().release()) :
-        nullptr
-    )
-  ));
-}
-
 std::string poi::Let::show() {
   return
     "(" +
@@ -205,18 +158,68 @@ std::shared_ptr<poi::Value> poi::Let::eval(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// DataConstructor                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+poi::DataConstructor::DataConstructor(
+  std::shared_ptr<std::string> name,
+  size_t name_id,
+  std::shared_ptr<std::vector<std::shared_ptr<std::string>>> params,
+  std::shared_ptr<std::vector<size_t>> param_ids
+) : name(name), name_id(name_id), params(params), param_ids(param_ids) {
+}
+
+std::string poi::DataConstructor::show() {
+  auto result = *name;
+  for (auto param : *params) {
+    result += " " + *param;
+  }
+  return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// DataType                                                                  //
+///////////////////////////////////////////////////////////////////////////////
+
+poi::DataType::DataType(
+  std::shared_ptr<std::vector<poi::DataConstructor>> constructors
+) : constructors(constructors) {
+}
+
+std::string poi::DataType::show() {
+  std::string result = "data (";
+  for (
+    auto iter = constructors->begin();
+    iter != constructors->end();
+    ++iter
+  ) {
+    result += iter->show();
+    if (iter + 1 < constructors->end()) {
+      result += ", ";
+    }
+  }
+  result += ")";
+  return result;
+}
+
+std::shared_ptr<poi::Value> poi::DataType::eval(
+  std::shared_ptr<poi::Term> term,
+  std::unordered_map<size_t, std::shared_ptr<poi::Value>> &environment
+) {
+  throw poi::Error(
+    "eval(...) has not been implemented for poi::DataType.",
+    *source, *source_name,
+    start_pos, end_pos
+  );
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // Group                                                                     //
 ///////////////////////////////////////////////////////////////////////////////
 
 poi::Group::Group(
   std::shared_ptr<poi::Term> body
 ) : body(body) {
-}
-
-std::unique_ptr<poi::Term> poi::Group::clone() {
-  return std::unique_ptr<Term>(new Group(
-    body ? std::shared_ptr<Term>(body->clone().release()) : nullptr
-  ));
 }
 
 std::string poi::Group::show() {

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -113,7 +113,7 @@ std::unique_ptr<std::vector<poi::Token>> poi::tokenize(
       line_continuation_status = LineContinuationStatus::LCS_DEFAULT;
     }
 
-    // IDENTIFIER
+    // IDENTIFIERs and keywords
     // Identifiers consist of ASCII letters, digits, and underscores, and must
     // not start with a letter. We also accept any bytes >= 0x80, which allows
     // for Unicode symbols.
@@ -131,12 +131,21 @@ std::unique_ptr<std::vector<poi::Token>> poi::tokenize(
       }
       size_t length = end_pos - pos;
       auto literal = source->substr(pos, length);
-      tokens.push_back(Token(
-        TokenType::IDENTIFIER,
-        intern(intern_pool, literal),
-        source_name, source,
-        pos, end_pos
-      ));
+      if (literal == "data") {
+        tokens.push_back(Token(
+          TokenType::DATA,
+          intern(intern_pool, literal),
+          source_name, source,
+          pos, end_pos
+        ));
+      } else {
+        tokens.push_back(Token(
+          TokenType::IDENTIFIER,
+          intern(intern_pool, literal),
+          source_name, source,
+          pos, end_pos
+        ));
+      }
       pos = end_pos;
       continue;
     }


### PR DESCRIPTION
Add support for parsing ADTs. Examples:

    # A bool is either true or false.
    bool = data (true, false)

    # A maybe represents a value that might be missing.
    maybe = data (none, just x)

    tree = data (
      empty
      left x
      right x
    )

    tree

These examples are parsed as:

    (bool = data (true, false), (maybe = data (none, just x), (tree = data (empty, left x, right x), tree)))

**Status:** Ready

**Fixes:** N/A
