### PR TITLE
Make data types first-class values

### DIFF
--- a/include/ast.h
+++ b/include/ast.h
@@ -14,7 +14,7 @@
 
 namespace poi {
 
-  class Value; // Declared in gram/value.h
+  class Value; // Declared in poi/value.h
 
   class Term {
   public:

--- a/include/value.h
+++ b/include/value.h
@@ -11,7 +11,8 @@
 
 namespace poi {
 
-  class Abstraction; // Declared in gram/ast.h
+  class Abstraction; // Declared in poi/ast.h
+  class DataType; // Declared in poi/ast.h
 
   class Value {
   public:
@@ -27,6 +28,16 @@ namespace poi {
     explicit FunctionValue(
       std::shared_ptr<poi::Abstraction> abstraction,
       std::unordered_map<size_t, std::shared_ptr<poi::Value>> &captures
+    );
+    std::string show() override;
+  };
+
+  class DataTypeValue : public Value {
+  public:
+    std::shared_ptr<poi::DataType> data_type;
+
+    explicit DataTypeValue(
+      std::shared_ptr<poi::DataType> data_type
     );
     std::string show() override;
   };

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -92,7 +92,7 @@ std::shared_ptr<poi::Value> poi::Application::eval(
   );
   if (!abstraction_value_fun) {
     throw poi::Error(
-      abstraction_value->show() + "is not a function.",
+      abstraction_value->show() + " is not a function.",
       *source, *source_name,
       start_pos, end_pos
     );
@@ -206,10 +206,8 @@ std::shared_ptr<poi::Value> poi::DataType::eval(
   std::shared_ptr<poi::Term> term,
   std::unordered_map<size_t, std::shared_ptr<poi::Value>> &environment
 ) {
-  throw poi::Error(
-    "eval(...) has not been implemented for poi::DataType.",
-    *source, *source_name,
-    start_pos, end_pos
+  return std::make_shared<poi::DataTypeValue>(
+    std::dynamic_pointer_cast<poi::DataType>(term)
   );
 }
 

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -21,3 +21,16 @@ poi::FunctionValue::FunctionValue(
 std::string poi::FunctionValue::show() {
   return abstraction->show();
 }
+
+///////////////////////////////////////////////////////////////////////////////
+// DataTypeValue                                                             //
+///////////////////////////////////////////////////////////////////////////////
+
+poi::DataTypeValue::DataTypeValue(
+  std::shared_ptr<poi::DataType> data_type
+) : data_type(data_type) {
+}
+
+std::string poi::DataTypeValue::show() {
+  return data_type->show();
+}


### PR DESCRIPTION
Make data types first-class values. Now the following successfully runs:

    bool = data (true, false)
    (x -> x) bool

It evaluates to `data (true, false)`. But what what happens if we try this:

    bool = data (true, false)
    bool (x -> x)

We get the following error:

    Error: data (true, false) is not a function.
    test.poi @ 3:1 - 3:13

    bool (x -> x)
    ^^^^^^^^^^^^^

Dynamic type checking!

**Status:** Ready

**Fixes:** N/A
