### PR TITLE
Add support for constructing ADTs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Let bindings:
 Algebraic data types:
 
     bool = data (true, false)
+    true = bool.true
+    false = bool.false
 
     maybe = data (none, just value)
 
@@ -38,7 +40,8 @@ Algebraic data types:
       node left value right
     )
 
-    tree
+    subtree = tree.node tree.empty true tree.empty
+    tree.node subtree false subtree
 
 Grouping:
 

--- a/include/value.h
+++ b/include/value.h
@@ -23,11 +23,15 @@ namespace poi {
   class FunctionValue : public Value {
   public:
     std::shared_ptr<poi::Abstraction> abstraction;
-    std::unordered_map<size_t, std::shared_ptr<poi::Value>> captures;
+    std::shared_ptr<
+      std::unordered_map<size_t, std::shared_ptr<poi::Value>>
+    > captures;
 
     explicit FunctionValue(
       std::shared_ptr<poi::Abstraction> abstraction,
-      std::unordered_map<size_t, std::shared_ptr<poi::Value>> &captures
+      std::shared_ptr<
+        std::unordered_map<size_t, std::shared_ptr<poi::Value>>
+      > captures
     );
     std::string show(poi::StringPool &pool) override;
   };
@@ -46,12 +50,16 @@ namespace poi {
   public:
     std::shared_ptr<poi::DataTypeValue> type;
     std::size_t constructor;
-    std::shared_ptr<std::vector<std::shared_ptr<poi::Value>>> members;
+    std::shared_ptr<
+      std::unordered_map<size_t, std::shared_ptr<poi::Value>>
+    > captures;
 
     explicit DataValue(
       std::shared_ptr<poi::DataTypeValue> type,
       std::size_t constructor,
-      std::shared_ptr<std::vector<std::shared_ptr<poi::Value>>> members
+      std::shared_ptr<
+        std::unordered_map<size_t, std::shared_ptr<poi::Value>>
+      > captures
     );
     std::string show(poi::StringPool &pool) override;
   };

--- a/src/optimizer.cpp
+++ b/src/optimizer.cpp
@@ -10,21 +10,51 @@ std::shared_ptr<poi::Term> poi::optimize(std::shared_ptr<poi::Term> term) {
   }
   auto abstraction = std::dynamic_pointer_cast<poi::Abstraction>(term);
   if (abstraction) {
+    auto free_variables = std::make_shared<std::unordered_set<size_t>>();
+    free_variables->insert(
+      abstraction->free_variables->begin(),
+      abstraction->free_variables->end()
+    );
     return std::make_shared<poi::Abstraction>(
+      abstraction->source_name,
+      abstraction->source,
+      abstraction->start_pos,
+      abstraction->end_pos,
+      free_variables,
       abstraction->variable,
       optimize(abstraction->body)
     );
   }
   auto application = std::dynamic_pointer_cast<poi::Application>(term);
   if (application) {
+    auto free_variables = std::make_shared<std::unordered_set<size_t>>();
+    free_variables->insert(
+      application->free_variables->begin(),
+      application->free_variables->end()
+    );
     return std::make_shared<poi::Application>(
+      application->source_name,
+      application->source,
+      application->start_pos,
+      application->end_pos,
+      free_variables,
       optimize(application->abstraction),
       optimize(application->operand)
     );
   }
   auto let = std::dynamic_pointer_cast<poi::Let>(term);
   if (let) {
+    auto free_variables = std::make_shared<std::unordered_set<size_t>>();
+    free_variables->insert(
+      let->free_variables->begin(),
+      let->free_variables->end()
+    );
     return std::make_shared<poi::Let>(
+      let->source_name,
+      let->source,
+      let->start_pos,
+      let->end_pos,
+      free_variables,
       let->variable,
       optimize(let->definition),
       optimize(let->body)

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -258,8 +258,8 @@ std::unique_ptr<std::vector<poi::Token>> poi::tokenize(
     if (iter->type == TokenType::SEPARATOR && !iter->explicit_separator) {
       // Skip redundant SEPARATOR tokens.
       if (
-        (iter + 1) != tokens.end() &&
-        (iter + 1)->type == TokenType::SEPARATOR
+        std::next(iter) != tokens.end() &&
+        std::next(iter)->type == TokenType::SEPARATOR
       ) {
         continue;
       }
@@ -276,12 +276,12 @@ std::unique_ptr<std::vector<poi::Token>> poi::tokenize(
       }
 
       // Don't add SEPARATOR tokens at the end of the file.
-      if ((iter + 1) == tokens.end()) {
+      if (std::next(iter) == tokens.end()) {
         continue;
       }
 
       // Don't add SEPARATOR tokens after a group opener.
-      auto next_token = *(iter + 1);
+      auto next_token = *std::next(iter);
       if (next_token.type == TokenType::RIGHT_PAREN) {
         continue;
       }

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -15,7 +15,9 @@ poi::Value::~Value() {
 
 poi::FunctionValue::FunctionValue(
   std::shared_ptr<poi::Abstraction> abstraction,
-  std::unordered_map<size_t, std::shared_ptr<poi::Value>> &captures
+  std::shared_ptr<
+    std::unordered_map<size_t, std::shared_ptr<poi::Value>>
+  > captures
 ) : abstraction(abstraction), captures(captures) {
 }
 
@@ -43,17 +45,17 @@ std::string poi::DataTypeValue::show(poi::StringPool &pool) {
 poi::DataValue::DataValue(
   std::shared_ptr<poi::DataTypeValue> type,
   std::size_t constructor,
-  std::shared_ptr<std::vector<std::shared_ptr<poi::Value>>> members
-) : type(type), constructor(constructor), members(members) {
+  std::shared_ptr<
+    std::unordered_map<size_t, std::shared_ptr<poi::Value>>
+  > captures
+) : type(type), constructor(constructor), captures(captures) {
 }
 
 std::string poi::DataValue::show(poi::StringPool &pool) {
-  std::string result =
-    "(" +
-    pool.find((*type->data_type->constructors)[constructor].name);
-  for (auto &member : *members) {
-    result += " " + member->show(pool);
+  std::string result = "(" + pool.find(constructor);
+  for (auto &capture : *captures) {
+    result += " " + capture.second->show(pool);
   }
-  result += " : " + type->show(pool) + ")";
+  result += ")";
   return result;
 }


### PR DESCRIPTION
Add support for constructing ADTs. The following examples are now supported:

#### Example 1: `maybe`

    maybe = data (none, just x)
    id = x -> x
    maybe.just id
    # => (just (x -> x))

#### Example 2: `bool`

    bool = data (true, false)
    true = bool.true
    false = bool.false
    true
    # => (true)

#### Example 3: Attempting to call the `maybe.just` constructor with too many arguments.

    maybe = data (none, just x)
    id = x -> x
    maybe.just id id
    # => Error: (just (x -> x)) is not a function.
    # => test.poi @ 33:1 - 33:13
    # => 
    # => maybe.just id id
    # => ^^^^^^^^^^^^^


**Status:** Ready

**Fixes:** N/A
