### PR TITLE
Make the install script more portable

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,8 @@
-#!/usr/bin/env bash
-set -eu -o pipefail
+#!/usr/bin/sh
 
-# This script downloads, builds, and installs Poi.
+# This script downloads, builds, and installs Poi. This is intended to be
+# curled and piped into a shell. It should work with any POSIX-compatible
+# shell.
 
 # Usage:
 #   ./install.sh


### PR DESCRIPTION
I tried to run the install command in Ubuntu:

    $ curl -sSf https://raw.githubusercontent.com/stepchowfun/poi/master/scripts/install.sh | sh
    sh: 2: set: Illegal option -o pipefail

This error happens because Ubuntu's default shell is dash, not bash, and dash doesn't support the `pipefail` option. The install script had a [shebang](https://en.wikipedia.org/wiki/Shebang_\(Unix\)) to specify that it should be run with bash, but apparently this is ignored when piping the script into dash.

This PR makes the install script more portable by removing the bash-specific options. The other two scripts are not intended to be piped into a shell, so we can assume their shebangs work (and I confirmed that this is the case for Ubuntu).

**Status:** Ready

**Fixes:** N/A
