### PR TITLE
Remove a redundant method declaration

### DIFF
--- a/include/ast.h
+++ b/include/ast.h
@@ -46,7 +46,6 @@ namespace poi {
       std::shared_ptr<std::unordered_set<size_t>> free_variables
     );
     virtual ~Term();
-    virtual std::string show(poi::StringPool &pool) = 0;
     virtual std::shared_ptr<poi::Value> eval(
       std::shared_ptr<poi::Term> term,
       std::unordered_map<size_t, std::shared_ptr<poi::Value>> &environment,


### PR DESCRIPTION
Remove a redundant method declaration. Good catch @ewang12.

**Status:** Ready

**Fixes:** N/A
