### PR TITLE
Add error checking for duplicate parameters in data constructors

### DIFF
--- a/tests/duplicate_constructor.json
+++ b/tests/duplicate_constructor.json
@@ -1,5 +1,5 @@
 {
-  "source": "option = data (some, some value), option.some",
+  "source": "data (some, some value)",
   "stdout": "",
   "exit_code": 1
 }

--- a/tests/duplicate_parameter_in_constructor.json
+++ b/tests/duplicate_parameter_in_constructor.json
@@ -1,0 +1,5 @@
+{
+  "source": "data (foo x x)",
+  "stdout": "",
+  "exit_code": 1
+}


### PR DESCRIPTION
Add error checking for duplicate parameters in data constructors. I also added a new test, simplified an existing test, fixed a bug in some existing error handling, and made some other existing error handling more robust.

**Status:** Ready

**Fixes:** N/A
