### PR TITLE
Implement `match` and update the syntax to use curly braces where appropriate

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,25 +27,21 @@ Let bindings:
     id = x -> x
     id
 
-Algebraic data types:
+Algebraic data types and pattern matching:
 
-    bool = data (true, false)
-    true = bool.true
-    false = bool.false
+    bool = data {true, false}
+    not = x -> match x {
+      {true} -> bool.false
+      {false} -> bool.true
+    }
 
-    option = data (none, some value)
+    option = data {none, some value}
+    map = f -> x -> match x {
+      {none} -> option.none
+      {some value} -> option.some (f value)
+    }
 
-    something = option.some true
-    something.value
-
-Pattern matching:
-
-    option = data (none, some value)
-    meal = option.some (option.some (x -> x))
-    {some burrito} = meal
-
-    f = {some {some z}} -> z
-    f meal
+    map not (option.some bool.false)
 
 Grouping:
 

--- a/include/ast.h
+++ b/include/ast.h
@@ -264,6 +264,32 @@ namespace Poi {
     ) const override;
   };
 
+  class Match : public Term {
+  public:
+    const std::shared_ptr<Poi::Term> discriminee;
+    const std::shared_ptr<
+      std::vector<std::shared_ptr<Poi::Abstraction>>
+    > cases;
+
+    explicit Match(
+      size_t source_name,
+      size_t source,
+      size_t start_pos,
+      size_t end_pos,
+      std::shared_ptr<std::unordered_set<size_t>> free_variables,
+      std::shared_ptr<Poi::Term> discriminee,
+      std::shared_ptr<
+        std::vector<std::shared_ptr<Poi::Abstraction>>
+      > cases
+    );
+    std::string show(const Poi::StringPool &pool) const override;
+    std::shared_ptr<Poi::Value> eval(
+      std::shared_ptr<Poi::Term> term,
+      std::unordered_map<size_t, std::shared_ptr<Poi::Value>> &environment,
+      Poi::StringPool &pool
+    ) const override;
+  };
+
 }
 
 #endif

--- a/include/token.h
+++ b/include/token.h
@@ -20,6 +20,7 @@ namespace Poi {
     IDENTIFIER,
     LEFT_CURLY,
     LEFT_PAREN,
+    MATCH,
     RIGHT_CURLY,
     RIGHT_PAREN,
     SEPARATOR
@@ -33,6 +34,7 @@ namespace Poi {
     "IDENTIFIER",
     "LEFT_CURLY",
     "LEFT_PAREN",
+    "MATCH",
     "RIGHT_CURLY",
     "RIGHT_PAREN",
     "SEPARATOR"
@@ -50,9 +52,12 @@ namespace Poi {
     const bool explicit_separator; // Only used for SEPARATOR tokens
 
     explicit Token(
-      Poi::TokenType type, size_t literal,
-      size_t source_name, size_t source,
-      size_t start_pos, size_t end_pos,
+      Poi::TokenType type,
+      size_t literal,
+      size_t source_name,
+      size_t source,
+      size_t start_pos,
+      size_t end_pos,
       bool explicit_separator
     );
     std::string show(Poi::StringPool &pool) const;

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -2,13 +2,19 @@
 #include <type_traits>
 
 Poi::Token::Token(
-  Poi::TokenType type, size_t literal,
-  size_t source_name, size_t source,
-  size_t start_pos, size_t end_pos,
+  Poi::TokenType type,
+  size_t literal,
+  size_t source_name,
+  size_t source,
+  size_t start_pos,
+  size_t end_pos,
   bool explicit_separator) :
-  type(type), literal(literal),
-  source_name(source_name), source(source),
-  start_pos(start_pos), end_pos(end_pos),
+  type(type),
+  literal(literal),
+  source_name(source_name),
+  source(source),
+  start_pos(start_pos),
+  end_pos(end_pos),
   explicit_separator(explicit_separator) {
 }
 

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -49,8 +49,10 @@ Poi::TokenStream Poi::tokenize(
       if (line_continuation_status != LineContinuationStatus::LCS_DEFAULT) {
         throw Error(
           "Duplicate '\\'.",
-          source_name_str, source_str,
-          pos, pos + 1
+          source_name_str,
+          source_str,
+          pos,
+          pos + 1
         );
       }
       line_continuation_status = LineContinuationStatus::LCS_WAIT_FOR_NEWLINE;
@@ -65,9 +67,12 @@ Poi::TokenStream Poi::tokenize(
       if (line_continuation_status == LineContinuationStatus::LCS_DEFAULT) {
         std::string literal("");
         tokens.push_back(Token(
-          TokenType::SEPARATOR, pool.insert(literal),
-          source_name, source,
-          pos, pos,
+          TokenType::SEPARATOR,
+          pool.insert(literal),
+          source_name,
+          source,
+          pos,
+          pos,
           false
         ));
       }
@@ -91,8 +96,10 @@ Poi::TokenStream Poi::tokenize(
     ) {
       throw Error(
         "Unexpected '\\'.",
-        source_name_str, source_str,
-        line_continuation_marker_pos, line_continuation_marker_pos + 1
+        source_name_str,
+        source_str,
+        line_continuation_marker_pos,
+        line_continuation_marker_pos + 1
       );
     }
 
@@ -125,16 +132,30 @@ Poi::TokenStream Poi::tokenize(
         tokens.push_back(Token(
           TokenType::DATA,
           pool.insert(literal),
-          source_name, source,
-          pos, end_pos,
+          source_name,
+          source,
+          pos,
+          end_pos,
+          false
+        ));
+      } else if (literal == "match") {
+        tokens.push_back(Token(
+          TokenType::MATCH,
+          pool.insert(literal),
+          source_name,
+          source,
+          pos,
+          end_pos,
           false
         ));
       } else {
         tokens.push_back(Token(
           TokenType::IDENTIFIER,
           pool.insert(literal),
-          source_name, source,
-          pos, end_pos,
+          source_name,
+          source,
+          pos,
+          end_pos,
           false
         ));
       }
@@ -157,22 +178,29 @@ Poi::TokenStream Poi::tokenize(
           if (grouping_stack.empty()) {
             throw Error(
               "Unmatched '" + literal + "'.",
-              source_name_str, source_str,
-              pos, pos + 1
+              source_name_str,
+              source_str,
+              pos,
+              pos + 1
             );
           } else if (grouping_stack.back().type != opener_type) {
             throw Error(
               "Unmatched '" + pool.find(grouping_stack.back().literal) + "'.",
-              source_name_str, source_str,
-              grouping_stack.back().start_pos, grouping_stack.back().end_pos
+              source_name_str,
+              source_str,
+              grouping_stack.back().start_pos,
+              grouping_stack.back().end_pos
             );
           }
           grouping_stack.pop_back();
         }
         Token token(
-          type, pool.insert(literal),
-          source_name, source,
-          pos, pos + literal.size(),
+          type,
+          pool.insert(literal),
+          source_name,
+          source,
+          pos,
+          pos + literal.size(),
           literal == ","
         );
         if (opener) {
@@ -249,8 +277,10 @@ Poi::TokenStream Poi::tokenize(
     // should be rejected.
     throw Error(
       "Unexpected character '" + source_str.substr(pos, 1) + "'.",
-      source_name_str, source_str,
-      pos, pos + 1
+      source_name_str,
+      source_str,
+      pos,
+      pos + 1
     );
   }
 
@@ -258,8 +288,10 @@ Poi::TokenStream Poi::tokenize(
   if (!grouping_stack.empty()) {
     throw Error(
       "Unmatched '" + pool.find(grouping_stack.back().literal) + "'.",
-      source_name_str, source_str,
-      grouping_stack.back().start_pos, grouping_stack.back().end_pos
+      source_name_str,
+      source_str,
+      grouping_stack.back().start_pos,
+      grouping_stack.back().end_pos
     );
   }
 
@@ -293,15 +325,21 @@ Poi::TokenStream Poi::tokenize(
         continue;
       }
 
-      // Don't add SEPARATOR tokens after a group opener.
+      // Don't add SEPARATOR tokens after an opener.
       auto next_token = *std::next(iter);
-      if (next_token.type == TokenType::RIGHT_PAREN) {
+      if (
+        next_token.type == TokenType::RIGHT_CURLY ||
+        next_token.type == TokenType::RIGHT_PAREN
+      ) {
         continue;
       }
 
-      // Don't add SEPARATOR tokens before a group closer.
+      // Don't add SEPARATOR tokens before a closer.
       auto prev_token = filtered_tokens->back();
-      if (prev_token.type == TokenType::LEFT_PAREN) {
+      if (
+        prev_token.type == TokenType::LEFT_CURLY ||
+        prev_token.type == TokenType::LEFT_PAREN
+      ) {
         continue;
       }
     }

--- a/tests/abstraction_pattern.json
+++ b/tests/abstraction_pattern.json
@@ -1,5 +1,5 @@
 {
-  "source": "option = data (none, some value), ({some x} -> x) (option.some (x -> x))",
+  "source": "option = data {none, some value}, ({some x} -> x) (option.some (x -> x))",
   "stdout": "(x -> x)\n",
   "stderr": "",
   "exit_code": 0

--- a/tests/bool.json
+++ b/tests/bool.json
@@ -1,6 +1,6 @@
 {
-  "source": "data (true, false)",
-  "stdout": "data (true, false)\n",
+  "source": "data {true, false}",
+  "stdout": "data {true, false}\n",
   "stderr": "",
   "exit_code": 0
 }

--- a/tests/constructor_function.json
+++ b/tests/constructor_function.json
@@ -1,5 +1,5 @@
 {
-  "source": "option = data (none, some value), option.some (x -> x)",
+  "source": "option = data {none, some value}, option.some (x -> x)",
   "stdout": "(some (x -> x))\n",
   "stderr": "",
   "exit_code": 0

--- a/tests/constructor_value.json
+++ b/tests/constructor_value.json
@@ -1,5 +1,5 @@
 {
-  "source": "option = data (none, some value), option.none",
+  "source": "option = data {none, some value}, option.none",
   "stdout": "(none)\n",
   "stderr": "",
   "exit_code": 0

--- a/tests/duplicate_constructor.json
+++ b/tests/duplicate_constructor.json
@@ -1,5 +1,5 @@
 {
-  "source": "data (some, some value)",
+  "source": "data {some, some value}",
   "stdout": "",
   "exit_code": 1
 }

--- a/tests/duplicate_parameter_in_constructor.json
+++ b/tests/duplicate_parameter_in_constructor.json
@@ -1,5 +1,5 @@
 {
-  "source": "data (foo x x)",
+  "source": "data {foo x x}",
   "stdout": "",
   "exit_code": 1
 }

--- a/tests/let_pattern.json
+++ b/tests/let_pattern.json
@@ -1,5 +1,5 @@
 {
-  "source": "option = data (none, some value), a = option.some (x -> x), {some b} = a, b",
+  "source": "option = data {none, some value}, a = option.some (x -> x), {some b} = a, b",
   "stdout": "(x -> x)\n",
   "stderr": "",
   "exit_code": 0

--- a/tests/map.json
+++ b/tests/map.json
@@ -1,0 +1,6 @@
+{
+  "source": "bool = data {true, false}, not = x -> match x {{true} -> bool.false, {false} -> bool.true}, option = data {none, some value}, map = f -> x -> match x {{none} -> option.none, {some value} -> option.some (f value)}, map not (option.some bool.false)",
+  "stdout": "(some (true))\n",
+  "stderr": "",
+  "exit_code": 0
+}

--- a/tests/match.json
+++ b/tests/match.json
@@ -1,0 +1,6 @@
+{
+  "source": "bool = data {true, false}, not = x -> match x {{true} -> bool.false, {false} -> bool.true}, not bool.false",
+  "stdout": "(true)\n",
+  "stderr": "",
+  "exit_code": 0
+}

--- a/tests/match_error.json
+++ b/tests/match_error.json
@@ -1,5 +1,5 @@
 {
-  "source": "option = data (none, some value), {none} = x -> x, x -> x",
+  "source": "option = data {none, some value}, {none} = x -> x, x -> x",
   "stdout": "",
   "exit_code": 1
 }

--- a/tests/maybe.json
+++ b/tests/maybe.json
@@ -1,6 +1,6 @@
 {
-  "source": "data (none, some value)",
-  "stdout": "data (none, some value)\n",
+  "source": "data {none, some value}",
+  "stdout": "data {none, some value}\n",
   "stderr": "",
   "exit_code": 0
 }

--- a/tests/member.json
+++ b/tests/member.json
@@ -1,5 +1,5 @@
 {
-  "source": "option = data (none, some value), m = option.some (x -> x), m.value",
+  "source": "option = data {none, some value}, m = option.some (x -> x), m.value",
   "stdout": "(x -> x)\n",
   "stderr": "",
   "exit_code": 0

--- a/tests/nested_member.json
+++ b/tests/nested_member.json
@@ -1,5 +1,5 @@
 {
-  "source": "option = data (none, some value), m = option.some (option.some (x -> x)), m.value.value",
+  "source": "option = data {none, some value}, m = option.some (option.some (x -> x)), m.value.value",
   "stdout": "(x -> x)\n",
   "stderr": "",
   "exit_code": 0

--- a/tests/tree.json
+++ b/tests/tree.json
@@ -1,5 +1,5 @@
 {
-  "source": "tree = data (empty, node left value right), tree.node (x -> x) (y -> y) (z -> z)",
+  "source": "tree = data {empty, node left value right}, tree.node (x -> x) (y -> y) (z -> z)",
   "stdout": "(node (x -> x) (y -> y) (z -> z))\n",
   "stderr": "",
   "exit_code": 0

--- a/tests/type_error.json
+++ b/tests/type_error.json
@@ -1,5 +1,5 @@
 {
-  "source": "bool = data (true, false), bool bool",
+  "source": "bool = data {true, false}, bool bool",
   "stdout": "",
   "exit_code": 1
 }

--- a/tests/unit.json
+++ b/tests/unit.json
@@ -1,6 +1,6 @@
 {
-  "source": "data (unit)",
-  "stdout": "data (unit)\n",
+  "source": "data {unit}",
+  "stdout": "data {unit}\n",
   "stderr": "",
   "exit_code": 0
 }

--- a/tests/void.json
+++ b/tests/void.json
@@ -1,6 +1,6 @@
 {
-  "source": "data ()",
-  "stdout": "data ()\n",
+  "source": "data {}",
+  "stdout": "data {}\n",
   "stderr": "",
   "exit_code": 0
 }


### PR DESCRIPTION
Implement the `match` construct and update the syntax to use curly braces where appropriate. I fixed all the existing tests (changing parens to curly braces where appropriate) and added a couple new tests for `match`.

Now we can do the following:

```
bool = data {true, false}
not = x -> match x {
  {true} -> bool.false
  {false} -> bool.true
}

option = data {none, some value}
map = f -> x -> match x {
  {none} -> option.none
  {some value} -> option.some (f value)
}

map not (option.some bool.false)
# => (some (true))
```

**Status:** Ready

**Fixes:** N/A
