### PR TITLE
Rename Abstraction -> Function and Let -> Definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Application:
 
     x -> x x
 
-Let bindings:
+Bindings:
 
     id = x -> x
     id

--- a/include/ast.h
+++ b/include/ast.h
@@ -118,12 +118,12 @@ namespace Poi {
     ) const override;
   };
 
-  class Abstraction : public Term {
+  class Function : public Term {
   public:
     const std::shared_ptr<Poi::Pattern> pattern;
     const std::shared_ptr<Poi::Term> body;
 
-    explicit Abstraction(
+    explicit Function(
       size_t source_name,
       size_t source,
       size_t start_pos,
@@ -142,7 +142,7 @@ namespace Poi {
 
   class Application : public Term {
   public:
-    const std::shared_ptr<Poi::Term> abstraction;
+    const std::shared_ptr<Poi::Term> function;
     const std::shared_ptr<Poi::Term> operand;
 
     explicit Application(
@@ -151,7 +151,7 @@ namespace Poi {
       size_t start_pos,
       size_t end_pos,
       std::shared_ptr<std::unordered_set<size_t>> free_variables,
-      std::shared_ptr<Poi::Term> abstraction,
+      std::shared_ptr<Poi::Term> function,
       std::shared_ptr<Poi::Term> operand
     );
     std::string show(const Poi::StringPool &pool) const override;
@@ -162,13 +162,13 @@ namespace Poi {
     ) const override;
   };
 
-  class Let : public Term {
+  class Binding : public Term {
   public:
     const std::shared_ptr<Poi::Pattern> pattern;
     const std::shared_ptr<Poi::Term> definition;
     const std::shared_ptr<Poi::Term> body;
 
-    explicit Let(
+    explicit Binding(
       size_t source_name,
       size_t source,
       size_t start_pos,
@@ -268,7 +268,7 @@ namespace Poi {
   public:
     const std::shared_ptr<Poi::Term> discriminee;
     const std::shared_ptr<
-      std::vector<std::shared_ptr<Poi::Abstraction>>
+      std::vector<std::shared_ptr<Poi::Function>>
     > cases;
 
     explicit Match(
@@ -279,7 +279,7 @@ namespace Poi {
       std::shared_ptr<std::unordered_set<size_t>> free_variables,
       std::shared_ptr<Poi::Term> discriminee,
       std::shared_ptr<
-        std::vector<std::shared_ptr<Poi::Abstraction>>
+        std::vector<std::shared_ptr<Poi::Function>>
       > cases
     );
     std::string show(const Poi::StringPool &pool) const override;

--- a/include/value.h
+++ b/include/value.h
@@ -13,7 +13,7 @@
 namespace Poi {
 
   // Forward declarations to avoid mutually recursive headers
-  class Abstraction; // Declared in poi/ast.h
+  class Function; // Declared in poi/ast.h
   class DataType; // Declared in poi/ast.h
 
   class Value {
@@ -24,13 +24,13 @@ namespace Poi {
 
   class FunctionValue : public Value {
   public:
-    const std::shared_ptr<Poi::Abstraction> abstraction;
+    const std::shared_ptr<Poi::Function> function;
     const std::shared_ptr<
       std::unordered_map<size_t, std::shared_ptr<Poi::Value>>
     > captures;
 
     explicit FunctionValue(
-      std::shared_ptr<Poi::Abstraction> abstraction,
+      std::shared_ptr<Poi::Function> function,
       std::shared_ptr<
         std::unordered_map<size_t, std::shared_ptr<Poi::Value>>
       > captures

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -14,15 +14,15 @@ Poi::Value::~Value() {
 ///////////////////////////////////////////////////////////////////////////////
 
 Poi::FunctionValue::FunctionValue(
-  std::shared_ptr<Poi::Abstraction> abstraction,
+  std::shared_ptr<Poi::Function> function,
   std::shared_ptr<
     std::unordered_map<size_t, std::shared_ptr<Poi::Value>>
   > captures
-) : abstraction(abstraction), captures(captures) {
+) : function(function), captures(captures) {
 }
 
 std::string Poi::FunctionValue::show(const Poi::StringPool &pool) const {
-  return abstraction->show(pool);
+  return function->show(pool);
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Rename `Abstraction` -> `Function` and `Let` -> `Definition`.

**Status:** Ready

**Fixes:** N/A
