### PR TITLE
Implement let recursion

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -1,0 +1,23 @@
+/*
+  This header declares some utility functions.
+*/
+
+#ifndef POI_UTIL_H
+#define POI_UTIL_H
+
+#include <memory>
+#include <poi/ast.h>
+#include <poi/string_pool.h>
+#include <unordered_set>
+
+namespace Poi {
+
+  void variables_from_pattern(
+    std::unordered_set<size_t> &variables,
+    std::shared_ptr<Poi::Pattern> pattern,
+    Poi::StringPool &pool
+  );
+
+}
+
+#endif

--- a/include/value.h
+++ b/include/value.h
@@ -66,6 +66,17 @@ namespace Poi {
     std::string show(const Poi::StringPool &pool) const override;
   };
 
+  // Used to "tie the knot" for recursive bindings
+  class ProxyValue : public Value {
+  public:
+    std::shared_ptr<Poi::Value> value;
+
+    explicit ProxyValue(
+      std::shared_ptr<Poi::Value> value
+    );
+    std::string show(const Poi::StringPool &pool) const override;
+  };
+
 }
 
 #endif

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,0 +1,35 @@
+#include <poi/error.h>
+#include <poi/util.h>
+
+void Poi::variables_from_pattern(
+  std::unordered_set<size_t> &variables,
+  std::shared_ptr<Poi::Pattern> pattern,
+  Poi::StringPool &pool
+) {
+  auto variable_pattern = std::dynamic_pointer_cast<Poi::VariablePattern>(
+    pattern
+  );
+  if (variable_pattern) {
+    if (variables.find(variable_pattern->variable) != variables.end()) {
+      throw Poi::Error(
+        "Duplicate variable '" +
+          pool.find(variable_pattern->variable) +
+          "' in pattern.",
+        pool.find(pattern->source_name),
+        pool.find(pattern->source),
+        pattern->start_pos,
+        pattern->end_pos
+      );
+    }
+    variables.insert(variable_pattern->variable);
+  }
+
+  auto constructor_pattern = std::dynamic_pointer_cast<
+    Poi::ConstructorPattern
+  >(pattern);
+  if (constructor_pattern) {
+    for (auto &parameter : *(constructor_pattern->parameters)) {
+      variables_from_pattern(variables, parameter, pool);
+    }
+  }
+}

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -59,3 +59,20 @@ std::string Poi::DataValue::show(const Poi::StringPool &pool) const {
   result += ")";
   return result;
 }
+
+///////////////////////////////////////////////////////////////////////////////
+// ProxyValue                                                                //
+///////////////////////////////////////////////////////////////////////////////
+
+Poi::ProxyValue::ProxyValue(
+  std::shared_ptr<Poi::Value> value
+) : value(value) {
+}
+
+std::string Poi::ProxyValue::show(const Poi::StringPool &pool) const {
+  if (value) {
+    return value->show(pool);
+  } else {
+    throw Poi::Error("Undefined.");
+  }
+}

--- a/tests/nat.json
+++ b/tests/nat.json
@@ -1,0 +1,6 @@
+{
+  "source": "nat = data {zero, succ n}, add = x -> y -> match x {{zero} -> y, {succ n} -> nat.succ (add n y)}, two = nat.succ (nat.succ nat.zero), three = nat.succ (nat.succ (nat.succ nat.zero)), add two three",
+  "stdout": "(succ (succ (succ (succ (succ (zero))))))\n",
+  "stderr": "",
+  "exit_code": 0
+}


### PR DESCRIPTION
Implement let recursion. Now we can do this:

```
nat = data {zero, succ n}
add = x -> y -> match x {
  {zero} -> y
  {succ n} -> nat.succ (add n y)
}
two = nat.succ (nat.succ nat.zero)
three = nat.succ (nat.succ (nat.succ nat.zero))
add two three
# => (succ (succ (succ (succ (succ (zero))))))
```

This is what happens if we try to do a recursive reference outside of a function:

```
x = x
x

Error: Recursive references must occur in function bodies.
Location: example.poi @ 1:5

x = x
    ^
```

**Status:** Ready

**Fixes:** N/A
