### PR TITLE
Remove extra line breaks surrounding namespace bodies

### DIFF
--- a/include/ast.h
+++ b/include/ast.h
@@ -12,7 +12,6 @@
 #include <vector>
 
 namespace Poi {
-
   // Forward declarations to avoid mutually recursive headers
   class Value; // Declared in poi/value.h
   class DataTypeValue; // Declared in poi/value.h
@@ -289,7 +288,6 @@ namespace Poi {
       Poi::StringPool &pool
     ) const override;
   };
-
 }
 
 #endif

--- a/include/error.h
+++ b/include/error.h
@@ -8,7 +8,6 @@
 #include <string>
 
 namespace Poi {
-
   class Error {
   private:
     std::string message;
@@ -32,7 +31,6 @@ namespace Poi {
     virtual ~Error();
     std::string what() const; // No trailing line break
   };
-
 }
 
 #endif

--- a/include/parser.h
+++ b/include/parser.h
@@ -11,13 +11,11 @@
 #include <poi/token.h>
 
 namespace Poi {
-
   // Parse a stream of tokens.
   std::shared_ptr<Poi::Term> parse(
     const Poi::TokenStream &token_stream,
     Poi::StringPool &pool
   );
-
 }
 
 #endif

--- a/include/string_pool.h
+++ b/include/string_pool.h
@@ -9,7 +9,6 @@
 #include <unordered_map>
 
 namespace Poi {
-
   // A StringPool assigns an ID to every string. Two strings will have the
   // same ID if and only if they are equal.
   class StringPool {
@@ -23,7 +22,6 @@ namespace Poi {
     std::unordered_map<size_t, std::string> reverse_pool;
     size_t counter;
   };
-
 }
 
 #endif

--- a/include/token.h
+++ b/include/token.h
@@ -11,7 +11,6 @@
 #include <vector>
 
 namespace Poi {
-
   enum class TokenType {
     ARROW,
     DATA,
@@ -75,7 +74,6 @@ namespace Poi {
       std::shared_ptr<std::vector<Poi::Token>> tokens
     );
   };
-
 }
 
 #endif

--- a/include/tokenizer.h
+++ b/include/tokenizer.h
@@ -9,7 +9,6 @@
 #include <poi/token.h>
 
 namespace Poi {
-
   // Perform lexical analysis. The tokenizer guarantees that all LEFT_*/RIGHT_*
   // tokens will be matched in the returned stream.
   Poi::TokenStream tokenize(
@@ -17,7 +16,6 @@ namespace Poi {
     size_t source,
     Poi::StringPool &pool
   );
-
 }
 
 #endif

--- a/include/util.h
+++ b/include/util.h
@@ -11,13 +11,11 @@
 #include <unordered_set>
 
 namespace Poi {
-
   void variables_from_pattern(
     std::unordered_set<size_t> &variables,
     std::shared_ptr<Poi::Pattern> pattern,
     Poi::StringPool &pool
   );
-
 }
 
 #endif

--- a/include/value.h
+++ b/include/value.h
@@ -11,7 +11,6 @@
 #include <unordered_map>
 
 namespace Poi {
-
   // Forward declarations to avoid mutually recursive headers
   class Function; // Declared in poi/ast.h
   class DataType; // Declared in poi/ast.h
@@ -76,7 +75,6 @@ namespace Poi {
     );
     std::string show(const Poi::StringPool &pool) const override;
   };
-
 }
 
 #endif

--- a/include/version.h
+++ b/include/version.h
@@ -6,7 +6,6 @@
 #define POI_VERSION_H
 
 namespace Poi {
-
   // The version string
   extern const char * const VERSION;
 
@@ -15,7 +14,6 @@ namespace Poi {
 
   // 'release' or 'debug'
   extern const char * const BUILD_TYPE;
-
 }
 
 #endif

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -8,7 +8,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 namespace Poi {
-
   // This is used to signal errors in pattern matching.
   class MatchError : public Error {
   public:
@@ -33,7 +32,6 @@ namespace Poi {
     ) : Error (message, source_name, source, start_pos, end_pos) {
     };
   };
-
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -73,7 +73,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 namespace Poi {
-
   // If we encounter an error while parsing, we may backtrack and try a
   // different branch of execution. This may lead to more errors. If all the
   // branches lead to an error, we need to choose one of the errors to show
@@ -197,7 +196,6 @@ namespace Poi {
       }
     }
   };
-
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Remove extra line breaks surrounding namespace bodies. What do you think about this?

I think it looked weird to have this at the end of every file:

```
    };
  };

}
```

With this change, we would have:

```
    };
  };
}
```

**Status:** Ready

**Fixes:** N/A
