### PR TITLE
Fix a bug regarding the free variables of a binding expression

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1314,6 +1314,10 @@ Poi::ParseResult<Poi::Binding> parse_binding(
   // Construct the Binding.
   auto free_variables = std::make_shared<std::unordered_set<size_t>>();
   free_variables->insert(
+    definition.node->free_variables->begin(),
+    definition.node->free_variables->end()
+  );
+  free_variables->insert(
     body.node->free_variables->begin(),
     body.node->free_variables->end()
   );


### PR DESCRIPTION
Fix a bug regarding the free variables of a binding expression. Thanks @ewang12 for discovering this example which triggers the bug:

```
f = x -> \
  g = f
  g
f (x -> x)
```

**Status:** Ready

**Fixes:** N/A
