### PR TITLE
Do not have AST nodes store pointers to values

### DIFF
--- a/include/ast.h
+++ b/include/ast.h
@@ -12,9 +12,8 @@
 #include <vector>
 
 namespace Poi {
-  // Forward declarations to avoid mutually recursive headers
+  // A forward declaration to avoid mutually recursive headers
   class Value; // Declared in poi/value.h
-  class DataTypeValue; // Declared in poi/value.h
 
   class Node {
   public:
@@ -243,7 +242,7 @@ namespace Poi {
   // syntax for Data terms.
   class Data : public Term {
   public:
-    const std::shared_ptr<Poi::DataTypeValue> type;
+    const std::shared_ptr<Poi::DataType> type;
     const size_t constructor;
 
     explicit Data(
@@ -252,7 +251,7 @@ namespace Poi {
       size_t start_pos,
       size_t end_pos,
       std::shared_ptr<std::unordered_set<size_t>> free_variables,
-      std::shared_ptr<Poi::DataTypeValue> type,
+      std::shared_ptr<Poi::DataType> type,
       size_t constructor
     );
     std::string show(const Poi::StringPool &pool) const override;

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -578,7 +578,7 @@ std::shared_ptr<Poi::Value> Poi::Member::eval(
         start_pos,
         end_pos,
         free_variables,
-        data_type_value,
+        data_type_value->data_type,
         field
       );
 
@@ -661,7 +661,7 @@ Poi::Data::Data(
   size_t start_pos,
   size_t end_pos,
   std::shared_ptr<std::unordered_set<size_t>> free_variables,
-  std::shared_ptr<Poi::DataTypeValue> type, size_t constructor
+  std::shared_ptr<Poi::DataType> type, size_t constructor
 ) : Term(
     source_name,
     source,
@@ -686,11 +686,7 @@ std::shared_ptr<Poi::Value> Poi::Data::eval(
   for (auto iter : *free_variables) {
     captures->insert({ iter, environment.at(iter) });
   }
-  return std::make_shared<Poi::DataValue>(
-    type->data_type,
-    constructor,
-    captures
-  );
+  return std::make_shared<Poi::DataValue>(type, constructor, captures);
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
I think AST nodes should never refer to values. It would be nice if the AST were a static thing that comes from parsing the program and not running it (so we only have to garbage collect values). This PR brings us closer to that.

**Status:** Ready

**Fixes:** N/A
