### PR TITLE
Make everything const-correct

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -117,7 +117,7 @@ int main(int argc, char *argv[]) {
     }
 
     // Evaluate the program.
-    std::unordered_map<size_t, std::shared_ptr<Poi::Value>> environment;
+    std::unordered_map<size_t, std::shared_ptr<const Poi::Value>> environment;
     auto value = term->eval(term, environment, pool);
     std::cout << value->show(pool) << "\n";
   } catch(Poi::Error &e) {

--- a/include/ast.h
+++ b/include/ast.h
@@ -61,7 +61,7 @@ namespace Poi {
   public:
     const size_t constructor;
     const std::shared_ptr<
-      std::vector<std::shared_ptr<Poi::Pattern>>
+      const std::vector<std::shared_ptr<const Poi::Pattern>>
     > parameters;
 
     explicit ConstructorPattern(
@@ -71,7 +71,7 @@ namespace Poi {
       size_t end_pos,
       size_t constructor,
       std::shared_ptr<
-        std::vector<std::shared_ptr<Poi::Pattern>>
+        const std::vector<std::shared_ptr<const Poi::Pattern>>
       > parameters
     );
     std::string show(const Poi::StringPool &pool) const override;
@@ -79,20 +79,22 @@ namespace Poi {
 
   class Term : public Node {
   public:
-    const std::shared_ptr<std::unordered_set<size_t>> free_variables;
+    const std::shared_ptr<const std::unordered_set<size_t>> free_variables;
 
     explicit Term(
       size_t source_name,
       size_t source,
       size_t start_pos,
       size_t end_pos,
-      std::shared_ptr<std::unordered_set<size_t>> free_variables
+      std::shared_ptr<const std::unordered_set<size_t>> free_variables
     );
     virtual ~Term();
-    virtual std::shared_ptr<Poi::Value> eval(
-      std::shared_ptr<Poi::Term> term,
-      std::unordered_map<size_t, std::shared_ptr<Poi::Value>> &environment,
-      Poi::StringPool &pool
+    virtual std::shared_ptr<const Poi::Value> eval(
+      std::shared_ptr<const Poi::Term> term,
+      const std::unordered_map<
+        size_t, std::shared_ptr<const Poi::Value>
+      > &environment,
+      const Poi::StringPool &pool
     ) const = 0;
   };
 
@@ -105,93 +107,101 @@ namespace Poi {
       size_t source,
       size_t start_pos,
       size_t end_pos,
-      std::shared_ptr<std::unordered_set<size_t>> free_variables,
+      std::shared_ptr<const std::unordered_set<size_t>> free_variables,
       size_t variable
     );
     std::string show(const Poi::StringPool &pool) const override;
-    std::shared_ptr<Poi::Value> eval(
-      std::shared_ptr<Poi::Term> term,
-      std::unordered_map<size_t, std::shared_ptr<Poi::Value>> &environment,
-      Poi::StringPool &pool
+    std::shared_ptr<const Poi::Value> eval(
+      std::shared_ptr<const Poi::Term> term,
+      const std::unordered_map<
+        size_t, std::shared_ptr<const Poi::Value>
+      > &environment,
+      const Poi::StringPool &pool
     ) const override;
   };
 
   class Function : public Term {
   public:
-    const std::shared_ptr<Poi::Pattern> pattern;
-    const std::shared_ptr<Poi::Term> body;
+    const std::shared_ptr<const Poi::Pattern> pattern;
+    const std::shared_ptr<const Poi::Term> body;
 
     explicit Function(
       size_t source_name,
       size_t source,
       size_t start_pos,
       size_t end_pos,
-      std::shared_ptr<std::unordered_set<size_t>> free_variables,
-      std::shared_ptr<Poi::Pattern> pattern,
-      std::shared_ptr<Poi::Term> body
+      std::shared_ptr<const std::unordered_set<size_t>> free_variables,
+      std::shared_ptr<const Poi::Pattern> pattern,
+      std::shared_ptr<const Poi::Term> body
     );
     std::string show(const Poi::StringPool &pool) const override;
-    std::shared_ptr<Poi::Value> eval(
-      std::shared_ptr<Poi::Term> term,
-      std::unordered_map<size_t, std::shared_ptr<Poi::Value>> &environment,
-      Poi::StringPool &pool
+    std::shared_ptr<const Poi::Value> eval(
+      std::shared_ptr<const Poi::Term> term,
+      const std::unordered_map<
+        size_t, std::shared_ptr<const Poi::Value>
+      > &environment,
+      const Poi::StringPool &pool
     ) const override;
   };
 
   class Application : public Term {
   public:
-    const std::shared_ptr<Poi::Term> function;
-    const std::shared_ptr<Poi::Term> operand;
+    const std::shared_ptr<const Poi::Term> function;
+    const std::shared_ptr<const Poi::Term> operand;
 
     explicit Application(
       size_t source_name,
       size_t source,
       size_t start_pos,
       size_t end_pos,
-      std::shared_ptr<std::unordered_set<size_t>> free_variables,
-      std::shared_ptr<Poi::Term> function,
-      std::shared_ptr<Poi::Term> operand
+      std::shared_ptr<const std::unordered_set<size_t>> free_variables,
+      std::shared_ptr<const Poi::Term> function,
+      std::shared_ptr<const Poi::Term> operand
     );
     std::string show(const Poi::StringPool &pool) const override;
-    std::shared_ptr<Poi::Value> eval(
-      std::shared_ptr<Poi::Term> term,
-      std::unordered_map<size_t, std::shared_ptr<Poi::Value>> &environment,
-      Poi::StringPool &pool
+    std::shared_ptr<const Poi::Value> eval(
+      std::shared_ptr<const Poi::Term> term,
+      const std::unordered_map<
+        size_t, std::shared_ptr<const Poi::Value>
+      > &environment,
+      const Poi::StringPool &pool
     ) const override;
   };
 
   class Binding : public Term {
   public:
-    const std::shared_ptr<Poi::Pattern> pattern;
-    const std::shared_ptr<Poi::Term> definition;
-    const std::shared_ptr<Poi::Term> body;
+    const std::shared_ptr<const Poi::Pattern> pattern;
+    const std::shared_ptr<const Poi::Term> definition;
+    const std::shared_ptr<const Poi::Term> body;
 
     explicit Binding(
       size_t source_name,
       size_t source,
       size_t start_pos,
       size_t end_pos,
-      std::shared_ptr<std::unordered_set<size_t>> free_variables,
-      std::shared_ptr<Poi::Pattern> pattern,
-      std::shared_ptr<Poi::Term> definition,
-      std::shared_ptr<Poi::Term> body
+      std::shared_ptr<const std::unordered_set<size_t>> free_variables,
+      std::shared_ptr<const Poi::Pattern> pattern,
+      std::shared_ptr<const Poi::Term> definition,
+      std::shared_ptr<const Poi::Term> body
     );
     std::string show(const Poi::StringPool &pool) const override;
-    std::shared_ptr<Poi::Value> eval(
-      std::shared_ptr<Poi::Term> term,
-      std::unordered_map<size_t, std::shared_ptr<Poi::Value>> &environment,
-      Poi::StringPool &pool
+    std::shared_ptr<const Poi::Value> eval(
+      std::shared_ptr<const Poi::Term> term,
+      const std::unordered_map<
+        size_t, std::shared_ptr<const Poi::Value>
+      > &environment,
+      const Poi::StringPool &pool
     ) const override;
   };
 
   class DataType : public Term {
   public:
-    const std::shared_ptr<std::vector<size_t>> constructor_names;
+    const std::shared_ptr<const std::vector<size_t>> constructor_names;
     const std::shared_ptr<
-      std::unordered_map<size_t, std::vector<size_t>>
+      const std::unordered_map<size_t, std::vector<size_t>>
     > constructor_params;
     const std::shared_ptr<
-      std::unordered_map<size_t, std::shared_ptr<Poi::Term>>
+      const std::unordered_map<size_t, std::shared_ptr<const Poi::Term>>
     > constructors;
 
     explicit DataType(
@@ -199,20 +209,22 @@ namespace Poi {
       size_t source,
       size_t start_pos,
       size_t end_pos,
-      std::shared_ptr<std::unordered_set<size_t>> free_variables,
-      std::shared_ptr<std::vector<size_t>> constructor_names,
+      std::shared_ptr<const std::unordered_set<size_t>> free_variables,
+      std::shared_ptr<const std::vector<size_t>> constructor_names,
       std::shared_ptr<
-        std::unordered_map<size_t, std::vector<size_t>>
+        const std::unordered_map<size_t, std::vector<size_t>>
       > constructor_params,
       std::shared_ptr<
-        std::unordered_map<size_t, std::shared_ptr<Poi::Term>>
+        const std::unordered_map<size_t, std::shared_ptr<const Poi::Term>>
       > constructors
     );
     std::string show(const Poi::StringPool &pool) const override;
-    std::shared_ptr<Poi::Value> eval(
-      std::shared_ptr<Poi::Term> term,
-      std::unordered_map<size_t, std::shared_ptr<Poi::Value>> &environment,
-      Poi::StringPool &pool
+    std::shared_ptr<const Poi::Value> eval(
+      std::shared_ptr<const Poi::Term> term,
+      const std::unordered_map<
+        size_t, std::shared_ptr<const Poi::Value>
+      > &environment,
+      const Poi::StringPool &pool
     ) const override;
   };
 
@@ -221,7 +233,7 @@ namespace Poi {
   // syntax for Data terms.
   class Data : public Term {
   public:
-    const std::weak_ptr<Poi::DataType> type;
+    const std::weak_ptr<const Poi::DataType> type;
     const size_t constructor;
 
     explicit Data(
@@ -229,15 +241,17 @@ namespace Poi {
       size_t source,
       size_t start_pos,
       size_t end_pos,
-      std::shared_ptr<std::unordered_set<size_t>> free_variables,
-      std::weak_ptr<Poi::DataType> type,
+      std::shared_ptr<const std::unordered_set<size_t>> free_variables,
+      std::weak_ptr<const Poi::DataType> type,
       size_t constructor
     );
     std::string show(const Poi::StringPool &pool) const override;
-    std::shared_ptr<Poi::Value> eval(
-      std::shared_ptr<Poi::Term> term,
-      std::unordered_map<size_t, std::shared_ptr<Poi::Value>> &environment,
-      Poi::StringPool &pool
+    std::shared_ptr<const Poi::Value> eval(
+      std::shared_ptr<const Poi::Term> term,
+      const std::unordered_map<
+        size_t, std::shared_ptr<const Poi::Value>
+      > &environment,
+      const Poi::StringPool &pool
     ) const override;
   };
 
@@ -248,7 +262,7 @@ namespace Poi {
   //    Example: `person.name`
   class Member : public Term {
   public:
-    const std::shared_ptr<Poi::Term> object;
+    const std::shared_ptr<const Poi::Term> object;
     const size_t field;
 
     explicit Member(
@@ -256,23 +270,25 @@ namespace Poi {
       size_t source,
       size_t start_pos,
       size_t end_pos,
-      std::shared_ptr<std::unordered_set<size_t>> free_variables,
-      std::shared_ptr<Poi::Term> object,
+      std::shared_ptr<const std::unordered_set<size_t>> free_variables,
+      std::shared_ptr<const Poi::Term> object,
       size_t field
     );
     std::string show(const Poi::StringPool &pool) const override;
-    std::shared_ptr<Poi::Value> eval(
-      std::shared_ptr<Poi::Term> term,
-      std::unordered_map<size_t, std::shared_ptr<Poi::Value>> &environment,
-      Poi::StringPool &pool
+    std::shared_ptr<const Poi::Value> eval(
+      std::shared_ptr<const Poi::Term> term,
+      const std::unordered_map<
+        size_t, std::shared_ptr<const Poi::Value>
+      > &environment,
+      const Poi::StringPool &pool
     ) const override;
   };
 
   class Match : public Term {
   public:
-    const std::shared_ptr<Poi::Term> discriminee;
+    const std::shared_ptr<const Poi::Term> discriminee;
     const std::shared_ptr<
-      std::vector<std::shared_ptr<Poi::Function>>
+      const std::vector<std::shared_ptr<const Poi::Function>>
     > cases;
 
     explicit Match(
@@ -280,17 +296,19 @@ namespace Poi {
       size_t source,
       size_t start_pos,
       size_t end_pos,
-      std::shared_ptr<std::unordered_set<size_t>> free_variables,
-      std::shared_ptr<Poi::Term> discriminee,
+      std::shared_ptr<const std::unordered_set<size_t>> free_variables,
+      std::shared_ptr<const Poi::Term> discriminee,
       std::shared_ptr<
-        std::vector<std::shared_ptr<Poi::Function>>
+        const std::vector<std::shared_ptr<const Poi::Function>>
       > cases
     );
     std::string show(const Poi::StringPool &pool) const override;
-    std::shared_ptr<Poi::Value> eval(
-      std::shared_ptr<Poi::Term> term,
-      std::unordered_map<size_t, std::shared_ptr<Poi::Value>> &environment,
-      Poi::StringPool &pool
+    std::shared_ptr<const Poi::Value> eval(
+      std::shared_ptr<const Poi::Term> term,
+      const std::unordered_map<
+        size_t, std::shared_ptr<const Poi::Value>
+      > &environment,
+      const Poi::StringPool &pool
     ) const override;
   };
 }

--- a/include/ast.h
+++ b/include/ast.h
@@ -216,6 +216,31 @@ namespace Poi {
     ) const override;
   };
 
+  // A Data term evaluates to a DataValue value. These terms show up in the
+  // automatically generated constructor functions. There is no concrete
+  // syntax for Data terms.
+  class Data : public Term {
+  public:
+    const std::weak_ptr<Poi::DataType> type;
+    const size_t constructor;
+
+    explicit Data(
+      size_t source_name,
+      size_t source,
+      size_t start_pos,
+      size_t end_pos,
+      std::shared_ptr<std::unordered_set<size_t>> free_variables,
+      std::weak_ptr<Poi::DataType> type,
+      size_t constructor
+    );
+    std::string show(const Poi::StringPool &pool) const override;
+    std::shared_ptr<Poi::Value> eval(
+      std::shared_ptr<Poi::Term> term,
+      std::unordered_map<size_t, std::shared_ptr<Poi::Value>> &environment,
+      Poi::StringPool &pool
+    ) const override;
+  };
+
   // A Member `t.x` can refer to one of two things:
   // a) If `t` is a data type, then `t.x` refers to one of its constructors.
   //    Example: `bool.true`
@@ -234,31 +259,6 @@ namespace Poi {
       std::shared_ptr<std::unordered_set<size_t>> free_variables,
       std::shared_ptr<Poi::Term> object,
       size_t field
-    );
-    std::string show(const Poi::StringPool &pool) const override;
-    std::shared_ptr<Poi::Value> eval(
-      std::shared_ptr<Poi::Term> term,
-      std::unordered_map<size_t, std::shared_ptr<Poi::Value>> &environment,
-      Poi::StringPool &pool
-    ) const override;
-  };
-
-  // A Data term evaluates to a DataValue value. These terms show up in the
-  // automatically generated constructor functions. There is no concrete
-  // syntax for Data terms.
-  class Data : public Term {
-  public:
-    const std::weak_ptr<Poi::DataType> type;
-    const size_t constructor;
-
-    explicit Data(
-      size_t source_name,
-      size_t source,
-      size_t start_pos,
-      size_t end_pos,
-      std::shared_ptr<std::unordered_set<size_t>> free_variables,
-      std::weak_ptr<Poi::DataType> type,
-      size_t constructor
     );
     std::string show(const Poi::StringPool &pool) const override;
     std::shared_ptr<Poi::Value> eval(

--- a/include/parser.h
+++ b/include/parser.h
@@ -12,9 +12,9 @@
 
 namespace Poi {
   // Parse a stream of tokens.
-  std::shared_ptr<Poi::Term> parse(
+  std::shared_ptr<const Poi::Term> parse(
     const Poi::TokenStream &token_stream,
-    Poi::StringPool &pool
+    const Poi::StringPool &pool
   );
 }
 

--- a/include/token.h
+++ b/include/token.h
@@ -66,12 +66,12 @@ namespace Poi {
   public:
     const size_t source_name;
     const size_t source;
-    const std::shared_ptr<std::vector<Poi::Token>> tokens;
+    const std::shared_ptr<const std::vector<Poi::Token>> tokens;
 
     explicit TokenStream(
       size_t source_name,
       size_t source,
-      std::shared_ptr<std::vector<Poi::Token>> tokens
+      std::shared_ptr<const std::vector<Poi::Token>> tokens
     );
   };
 }

--- a/include/util.h
+++ b/include/util.h
@@ -13,8 +13,8 @@
 namespace Poi {
   void variables_from_pattern(
     std::unordered_set<size_t> &variables,
-    std::shared_ptr<Poi::Pattern> pattern,
-    Poi::StringPool &pool
+    std::shared_ptr<const Poi::Pattern> pattern,
+    const Poi::StringPool &pool
   );
 }
 

--- a/include/value.h
+++ b/include/value.h
@@ -23,15 +23,15 @@ namespace Poi {
 
   class FunctionValue : public Value {
   public:
-    const std::shared_ptr<Poi::Function> function;
+    const std::shared_ptr<const Poi::Function> function;
     const std::shared_ptr<
-      std::unordered_map<size_t, std::shared_ptr<Poi::Value>>
+      const std::unordered_map<size_t, std::shared_ptr<const Poi::Value>>
     > captures;
 
     explicit FunctionValue(
-      std::shared_ptr<Poi::Function> function,
+      std::shared_ptr<const Poi::Function> function,
       std::shared_ptr<
-        std::unordered_map<size_t, std::shared_ptr<Poi::Value>>
+        const std::unordered_map<size_t, std::shared_ptr<const Poi::Value>>
       > captures
     );
     std::string show(const Poi::StringPool &pool) const override;
@@ -39,27 +39,27 @@ namespace Poi {
 
   class DataTypeValue : public Value {
   public:
-    const std::shared_ptr<Poi::DataType> data_type;
+    const std::shared_ptr<const Poi::DataType> data_type;
 
     explicit DataTypeValue(
-      std::shared_ptr<Poi::DataType> data_type
+      std::shared_ptr<const Poi::DataType> data_type
     );
     std::string show(const Poi::StringPool &pool) const override;
   };
 
   class DataValue : public Value {
   public:
-    const std::shared_ptr<Poi::DataType> type;
+    const std::shared_ptr<const Poi::DataType> type;
     const std::size_t constructor;
     const std::shared_ptr<
-      std::unordered_map<size_t, std::shared_ptr<Poi::Value>>
+      const std::unordered_map<size_t, std::shared_ptr<const Poi::Value>>
     > captures;
 
     explicit DataValue(
-      std::shared_ptr<Poi::DataType> type,
+      std::shared_ptr<const Poi::DataType> type,
       std::size_t constructor,
       std::shared_ptr<
-        std::unordered_map<size_t, std::shared_ptr<Poi::Value>>
+        const std::unordered_map<size_t, std::shared_ptr<const Poi::Value>>
       > captures
     );
     std::string show(const Poi::StringPool &pool) const override;
@@ -68,10 +68,10 @@ namespace Poi {
   // Used to "tie the knot" for recursive bindings
   class ProxyValue : public Value {
   public:
-    const std::shared_ptr<Poi::Value> value;
+    const std::shared_ptr<const Poi::Value> value;
 
     explicit ProxyValue(
-      std::shared_ptr<Poi::Value> value
+      std::shared_ptr<const Poi::Value> value
     );
     std::string show(const Poi::StringPool &pool) const override;
   };

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -39,22 +39,26 @@ namespace Poi {
 ///////////////////////////////////////////////////////////////////////////////
 
 void pattern_match(
-  std::unordered_map<size_t, std::shared_ptr<Poi::Value>> &environment,
-  Poi::StringPool &pool,
-  std::shared_ptr<Poi::Pattern> pattern,
-  std::shared_ptr<Poi::Value> value
+  std::unordered_map<
+    size_t, std::shared_ptr<const Poi::Value>
+  > &environment,
+  const Poi::StringPool &pool,
+  std::shared_ptr<const Poi::Pattern> pattern,
+  std::shared_ptr<const Poi::Value> value
 ) {
-  auto variable_pattern = std::dynamic_pointer_cast<Poi::VariablePattern>(
-    pattern
-  );
+  auto variable_pattern = std::dynamic_pointer_cast<
+    const Poi::VariablePattern
+  >(pattern);
   if (variable_pattern) {
     auto iter = environment.find(variable_pattern->variable);
     if (iter != environment.end()) {
-      auto proxy_value = std::dynamic_pointer_cast<Poi::ProxyValue>(
+      auto proxy_value = std::dynamic_pointer_cast<const Poi::ProxyValue>(
         iter->second
       );
       if (proxy_value) {
-        const_cast<std::shared_ptr<Poi::Value> &>(proxy_value->value) = value;
+        const_cast<
+          std::shared_ptr<const Poi::Value> &
+        >(proxy_value->value) = value;
       }
       environment.erase(iter);
     }
@@ -63,10 +67,10 @@ void pattern_match(
   }
 
   auto constructor_pattern = std::dynamic_pointer_cast<
-    Poi::ConstructorPattern
+    const Poi::ConstructorPattern
   >(pattern);
   if (constructor_pattern) {
-    auto value_data = std::dynamic_pointer_cast<Poi::DataValue>(value);
+    auto value_data = std::dynamic_pointer_cast<const Poi::DataValue>(value);
     if (value_data) {
       if (
         value_data->type->constructor_params->find(
@@ -188,7 +192,9 @@ Poi::ConstructorPattern::ConstructorPattern(
   size_t start_pos,
   size_t end_pos,
   size_t constructor,
-  std::shared_ptr<std::vector<std::shared_ptr<Poi::Pattern>>> parameters
+  std::shared_ptr<
+    const std::vector<std::shared_ptr<const Poi::Pattern>>
+  > parameters
 ) : Pattern(
     source_name,
     source,
@@ -221,7 +227,7 @@ Poi::Term::Term(
   size_t source,
   size_t start_pos,
   size_t end_pos,
-  std::shared_ptr<std::unordered_set<size_t>> free_variables
+  std::shared_ptr<const std::unordered_set<size_t>> free_variables
 ) : Node(
     source_name,
     source,
@@ -242,7 +248,7 @@ Poi::Variable::Variable(
   size_t source,
   size_t start_pos,
   size_t end_pos,
-  std::shared_ptr<std::unordered_set<size_t>> free_variables,
+  std::shared_ptr<const std::unordered_set<size_t>> free_variables,
   size_t variable
 ) : Term(
     source_name,
@@ -257,14 +263,16 @@ std::string Poi::Variable::show(const Poi::StringPool &pool) const {
   return pool.find(variable);
 }
 
-std::shared_ptr<Poi::Value> Poi::Variable::eval(
-  std::shared_ptr<Poi::Term> term,
-  std::unordered_map<size_t, std::shared_ptr<Poi::Value>> &environment,
-  Poi::StringPool &pool
+std::shared_ptr<const Poi::Value> Poi::Variable::eval(
+  std::shared_ptr<const Poi::Term> term,
+  const std::unordered_map<
+    size_t, std::shared_ptr<const Poi::Value>
+  > &environment,
+  const Poi::StringPool &pool
 ) const {
   auto value = environment.at(variable);
   while (true) {
-    auto proxy_value = std::dynamic_pointer_cast<Poi::ProxyValue>(value);
+    auto proxy_value = std::dynamic_pointer_cast<const Poi::ProxyValue>(value);
     if (proxy_value) {
       value = proxy_value->value;
       if (!value) {
@@ -292,9 +300,9 @@ Poi::Function::Function(
   size_t source,
   size_t start_pos,
   size_t end_pos,
-  std::shared_ptr<std::unordered_set<size_t>> free_variables,
-  std::shared_ptr<Poi::Pattern> pattern,
-  std::shared_ptr<Poi::Term> body
+  std::shared_ptr<const std::unordered_set<size_t>> free_variables,
+  std::shared_ptr<const Poi::Pattern> pattern,
+  std::shared_ptr<const Poi::Term> body
 ) : Term(
     source_name,
     source,
@@ -308,19 +316,23 @@ std::string Poi::Function::show(const Poi::StringPool &pool) const {
   return "(" + pattern->show(pool) + " -> " + body->show(pool) + ")";
 }
 
-std::shared_ptr<Poi::Value> Poi::Function::eval(
-  std::shared_ptr<Poi::Term> term,
-  std::unordered_map<size_t, std::shared_ptr<Poi::Value>> &environment,
-  Poi::StringPool &pool
+std::shared_ptr<const Poi::Value> Poi::Function::eval(
+  std::shared_ptr<const Poi::Term> term,
+  const std::unordered_map<
+    size_t, std::shared_ptr<const Poi::Value>
+  > &environment,
+  const Poi::StringPool &pool
 ) const {
   auto captures = std::make_shared<
-    std::unordered_map<size_t, std::shared_ptr<Poi::Value>>
+    const std::unordered_map<size_t, std::shared_ptr<const Poi::Value>>
   >();
   for (auto iter : *free_variables) {
-    captures->insert({ iter, environment.at(iter) });
+    std::const_pointer_cast<
+      std::unordered_map<size_t, std::shared_ptr<const Poi::Value>>
+    >(captures)->insert({ iter, environment.at(iter) });
   }
   return std::make_shared<Poi::FunctionValue>(
-    std::dynamic_pointer_cast<Poi::Function>(term),
+    std::dynamic_pointer_cast<const Poi::Function>(term),
     captures
   );
 }
@@ -334,9 +346,9 @@ Poi::Application::Application(
   size_t source,
   size_t start_pos,
   size_t end_pos,
-  std::shared_ptr<std::unordered_set<size_t>> free_variables,
-  std::shared_ptr<Poi::Term> function,
-  std::shared_ptr<Poi::Term> operand
+  std::shared_ptr<const std::unordered_set<size_t>> free_variables,
+  std::shared_ptr<const Poi::Term> function,
+  std::shared_ptr<const Poi::Term> operand
 ) : Term(
     source_name,
     source,
@@ -350,14 +362,18 @@ std::string Poi::Application::show(const Poi::StringPool &pool) const {
   return "(" + function->show(pool) + " " + operand->show(pool) + ")";
 }
 
-std::shared_ptr<Poi::Value> Poi::Application::eval(
-  std::shared_ptr<Poi::Term> term,
-  std::unordered_map<size_t, std::shared_ptr<Poi::Value>> &environment,
-  Poi::StringPool &pool
+std::shared_ptr<const Poi::Value> Poi::Application::eval(
+  std::shared_ptr<const Poi::Term> term,
+  const std::unordered_map<
+    size_t, std::shared_ptr<const Poi::Value>
+  > &environment,
+  const Poi::StringPool &pool
 ) const {
   auto function_value = function->eval(function, environment, pool);
   auto operand_value = operand->eval(operand, environment, pool);
-  auto function_value_fun = std::dynamic_pointer_cast<Poi::FunctionValue>(
+  auto function_value_fun = std::dynamic_pointer_cast<
+    const Poi::FunctionValue
+  >(
     function_value
   );
   if (!function_value_fun) {
@@ -369,7 +385,9 @@ std::shared_ptr<Poi::Value> Poi::Application::eval(
       end_pos
     );
   }
-  std::unordered_map<size_t, std::shared_ptr<Poi::Value>> new_environment;
+  std::unordered_map<
+    size_t, std::shared_ptr<const Poi::Value>
+  > new_environment;
   for (auto iter : *(function_value_fun->captures)) {
     new_environment.insert(iter);
   }
@@ -399,10 +417,10 @@ Poi::Binding::Binding(
   size_t source,
   size_t start_pos,
   size_t end_pos,
-  std::shared_ptr<std::unordered_set<size_t>> free_variables,
-  std::shared_ptr<Poi::Pattern> pattern,
-  std::shared_ptr<Poi::Term> definition,
-  std::shared_ptr<Poi::Term> body
+  std::shared_ptr<const std::unordered_set<size_t>> free_variables,
+  std::shared_ptr<const Poi::Pattern> pattern,
+  std::shared_ptr<const Poi::Term> definition,
+  std::shared_ptr<const Poi::Term> body
 ) : Term(
     source_name,
     source,
@@ -423,10 +441,12 @@ std::string Poi::Binding::show(const Poi::StringPool &pool) const {
     ")";
 }
 
-std::shared_ptr<Poi::Value> Poi::Binding::eval(
-  std::shared_ptr<Poi::Term> term,
-  std::unordered_map<size_t, std::shared_ptr<Poi::Value>> &environment,
-  Poi::StringPool &pool
+std::shared_ptr<const Poi::Value> Poi::Binding::eval(
+  std::shared_ptr<const Poi::Term> term,
+  const std::unordered_map<
+    size_t, std::shared_ptr<const Poi::Value>
+  > &environment,
+  const Poi::StringPool &pool
 ) const {
   std::unordered_set<size_t> variables;
   Poi::variables_from_pattern(variables, pattern, pool);
@@ -462,13 +482,13 @@ Poi::DataType::DataType(
   size_t source,
   size_t start_pos,
   size_t end_pos,
-  std::shared_ptr<std::unordered_set<size_t>> free_variables,
-  std::shared_ptr<std::vector<size_t>> constructor_names,
+  std::shared_ptr<const std::unordered_set<size_t>> free_variables,
+  std::shared_ptr<const std::vector<size_t>> constructor_names,
   std::shared_ptr<
-    std::unordered_map<size_t, std::vector<size_t>>
+    const std::unordered_map<size_t, std::vector<size_t>>
   > constructor_params,
   std::shared_ptr<
-    std::unordered_map<size_t, std::shared_ptr<Poi::Term>>
+    const std::unordered_map<size_t, std::shared_ptr<const Poi::Term>>
   > constructors
 ) : Term(
     source_name,
@@ -501,13 +521,15 @@ std::string Poi::DataType::show(const Poi::StringPool &pool) const {
   return result;
 }
 
-std::shared_ptr<Poi::Value> Poi::DataType::eval(
-  std::shared_ptr<Poi::Term> term,
-  std::unordered_map<size_t, std::shared_ptr<Poi::Value>> &environment,
-  Poi::StringPool &pool
+std::shared_ptr<const Poi::Value> Poi::DataType::eval(
+  std::shared_ptr<const Poi::Term> term,
+  const std::unordered_map<
+    size_t, std::shared_ptr<const Poi::Value>
+  > &environment,
+  const Poi::StringPool &pool
 ) const {
   return std::make_shared<Poi::DataTypeValue>(
-    std::dynamic_pointer_cast<Poi::DataType>(term)
+    std::dynamic_pointer_cast<const Poi::DataType>(term)
   );
 }
 
@@ -520,8 +542,8 @@ Poi::Data::Data(
   size_t source,
   size_t start_pos,
   size_t end_pos,
-  std::shared_ptr<std::unordered_set<size_t>> free_variables,
-  std::weak_ptr<Poi::DataType> type,
+  std::shared_ptr<const std::unordered_set<size_t>> free_variables,
+  std::weak_ptr<const Poi::DataType> type,
   size_t constructor
 ) : Term(
     source_name,
@@ -536,13 +558,15 @@ std::string Poi::Data::show(const Poi::StringPool &pool) const {
   return "<" + type.lock()->show(pool) + "." + pool.find(constructor) + ">";
 }
 
-std::shared_ptr<Poi::Value> Poi::Data::eval(
-  std::shared_ptr<Poi::Term> term,
-  std::unordered_map<size_t, std::shared_ptr<Poi::Value>> &environment,
-  Poi::StringPool &pool
+std::shared_ptr<const Poi::Value> Poi::Data::eval(
+  std::shared_ptr<const Poi::Term> term,
+  const std::unordered_map<
+    size_t, std::shared_ptr<const Poi::Value>
+  > &environment,
+  const Poi::StringPool &pool
 ) const {
   auto captures = std::make_shared<
-    std::unordered_map<size_t, std::shared_ptr<Poi::Value>>
+    std::unordered_map<size_t, std::shared_ptr<const Poi::Value>>
   >();
   for (auto iter : *free_variables) {
     captures->insert({ iter, environment.at(iter) });
@@ -559,8 +583,8 @@ Poi::Member::Member(
   size_t source,
   size_t start_pos,
   size_t end_pos,
-  std::shared_ptr<std::unordered_set<size_t>> free_variables,
-  std::shared_ptr<Poi::Term> object,
+  std::shared_ptr<const std::unordered_set<size_t>> free_variables,
+  std::shared_ptr<const Poi::Term> object,
   size_t field
 ) : Term(
     source_name,
@@ -575,13 +599,15 @@ std::string Poi::Member::show(const Poi::StringPool &pool) const {
   return "(" + object->show(pool) + "." + pool.find(field) + ")";
 }
 
-std::shared_ptr<Poi::Value> Poi::Member::eval(
-  std::shared_ptr<Poi::Term> term,
-  std::unordered_map<size_t, std::shared_ptr<Poi::Value>> &environment,
-  Poi::StringPool &pool
+std::shared_ptr<const Poi::Value> Poi::Member::eval(
+  std::shared_ptr<const Poi::Term> term,
+  const std::unordered_map<
+    size_t, std::shared_ptr<const Poi::Value>
+  > &environment,
+  const Poi::StringPool &pool
 ) const {
   auto object_value = object->eval(object, environment, pool);
-  auto data_type_value = std::dynamic_pointer_cast<Poi::DataTypeValue>(
+  auto data_type_value = std::dynamic_pointer_cast<const Poi::DataTypeValue>(
     object_value
   );
   if (data_type_value) {
@@ -599,27 +625,29 @@ std::shared_ptr<Poi::Value> Poi::Member::eval(
     }
 
     // Check if the constructor is a Function.
-    auto constructor_function = std::dynamic_pointer_cast<Poi::Function>(
+    auto constructor_function = std::dynamic_pointer_cast<const Poi::Function>(
       constructor->second
     );
     if (constructor_function) {
       return std::make_shared<Poi::FunctionValue>(
         constructor_function,
         std::make_shared<
-          std::unordered_map<size_t, std::shared_ptr<Poi::Value>>
+          std::unordered_map<size_t, std::shared_ptr<const Poi::Value>>
         >()
       );
     } else {
       return std::make_shared<Poi::DataValue>(
-        std::dynamic_pointer_cast<Poi::Data>(constructor->second)->type.lock(),
+        std::dynamic_pointer_cast<const Poi::Data>(
+          constructor->second
+        )->type.lock(),
         field,
         std::make_shared<
-          std::unordered_map<size_t, std::shared_ptr<Poi::Value>>
+          std::unordered_map<size_t, std::shared_ptr<const Poi::Value>>
         >()
       );
     }
   } else {
-    auto data_value = std::dynamic_pointer_cast<Poi::DataValue>(
+    auto data_value = std::dynamic_pointer_cast<const Poi::DataValue>(
       object_value
     );
     if (data_value) {
@@ -658,10 +686,10 @@ Poi::Match::Match(
   size_t source,
   size_t start_pos,
   size_t end_pos,
-  std::shared_ptr<std::unordered_set<size_t>> free_variables,
-  std::shared_ptr<Poi::Term> discriminee,
+  std::shared_ptr<const std::unordered_set<size_t>> free_variables,
+  std::shared_ptr<const Poi::Term> discriminee,
   std::shared_ptr<
-    std::vector<std::shared_ptr<Poi::Function>>
+    const std::vector<std::shared_ptr<const Poi::Function>>
   > cases
 ) : Term(
     source_name,
@@ -686,14 +714,16 @@ std::string Poi::Match::show(const Poi::StringPool &pool) const {
   return result;
 }
 
-std::shared_ptr<Poi::Value> Poi::Match::eval(
-  std::shared_ptr<Poi::Term> term,
-  std::unordered_map<size_t, std::shared_ptr<Poi::Value>> &environment,
-  Poi::StringPool &pool
+std::shared_ptr<const Poi::Value> Poi::Match::eval(
+  std::shared_ptr<const Poi::Term> term,
+  const std::unordered_map<
+    size_t, std::shared_ptr<const Poi::Value>
+  > &environment,
+  const Poi::StringPool &pool
 ) const {
   auto discriminee_value = discriminee->eval(discriminee, environment, pool);
 
-  std::shared_ptr<Poi::Value> result;
+  std::shared_ptr<const Poi::Value> result;
   for (auto &c : *cases) {
     auto new_environment = environment;
     try {

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -512,6 +512,45 @@ std::shared_ptr<Poi::Value> Poi::DataType::eval(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// Data                                                                      //
+///////////////////////////////////////////////////////////////////////////////
+
+Poi::Data::Data(
+  size_t source_name,
+  size_t source,
+  size_t start_pos,
+  size_t end_pos,
+  std::shared_ptr<std::unordered_set<size_t>> free_variables,
+  std::weak_ptr<Poi::DataType> type,
+  size_t constructor
+) : Term(
+    source_name,
+    source,
+    start_pos,
+    end_pos,
+    free_variables
+), type(type), constructor(constructor) {
+}
+
+std::string Poi::Data::show(const Poi::StringPool &pool) const {
+  return "<" + type.lock()->show(pool) + "." + pool.find(constructor) + ">";
+}
+
+std::shared_ptr<Poi::Value> Poi::Data::eval(
+  std::shared_ptr<Poi::Term> term,
+  std::unordered_map<size_t, std::shared_ptr<Poi::Value>> &environment,
+  Poi::StringPool &pool
+) const {
+  auto captures = std::make_shared<
+    std::unordered_map<size_t, std::shared_ptr<Poi::Value>>
+  >();
+  for (auto iter : *free_variables) {
+    captures->insert({ iter, environment.at(iter) });
+  }
+  return std::make_shared<Poi::DataValue>(type.lock(), constructor, captures);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // Member                                                                    //
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -608,45 +647,6 @@ std::shared_ptr<Poi::Value> Poi::Member::eval(
       );
     }
   }
-}
-
-///////////////////////////////////////////////////////////////////////////////
-// Data                                                                      //
-///////////////////////////////////////////////////////////////////////////////
-
-Poi::Data::Data(
-  size_t source_name,
-  size_t source,
-  size_t start_pos,
-  size_t end_pos,
-  std::shared_ptr<std::unordered_set<size_t>> free_variables,
-  std::weak_ptr<Poi::DataType> type,
-  size_t constructor
-) : Term(
-    source_name,
-    source,
-    start_pos,
-    end_pos,
-    free_variables
-), type(type), constructor(constructor) {
-}
-
-std::string Poi::Data::show(const Poi::StringPool &pool) const {
-  return "<" + type.lock()->show(pool) + "." + pool.find(constructor) + ">";
-}
-
-std::shared_ptr<Poi::Value> Poi::Data::eval(
-  std::shared_ptr<Poi::Term> term,
-  std::unordered_map<size_t, std::shared_ptr<Poi::Value>> &environment,
-  Poi::StringPool &pool
-) const {
-  auto captures = std::make_shared<
-    std::unordered_map<size_t, std::shared_ptr<Poi::Value>>
-  >();
-  for (auto iter : *free_variables) {
-    captures->insert({ iter, environment.at(iter) });
-  }
-  return std::make_shared<Poi::DataValue>(type.lock(), constructor, captures);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -29,7 +29,7 @@ std::string Poi::Token::show(Poi::StringPool &pool) const {
 Poi::TokenStream::TokenStream(
   size_t source_name,
   size_t source,
-  std::shared_ptr<std::vector<Poi::Token>> tokens
+  std::shared_ptr<const std::vector<Poi::Token>> tokens
 ) :
   source_name(source_name),
   source(source),

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -3,12 +3,12 @@
 
 void Poi::variables_from_pattern(
   std::unordered_set<size_t> &variables,
-  std::shared_ptr<Poi::Pattern> pattern,
-  Poi::StringPool &pool
+  std::shared_ptr<const Poi::Pattern> pattern,
+  const Poi::StringPool &pool
 ) {
-  auto variable_pattern = std::dynamic_pointer_cast<Poi::VariablePattern>(
-    pattern
-  );
+  auto variable_pattern = std::dynamic_pointer_cast<
+    const Poi::VariablePattern
+  >(pattern);
   if (variable_pattern) {
     if (variables.find(variable_pattern->variable) != variables.end()) {
       throw Poi::Error(
@@ -25,7 +25,7 @@ void Poi::variables_from_pattern(
   }
 
   auto constructor_pattern = std::dynamic_pointer_cast<
-    Poi::ConstructorPattern
+    const Poi::ConstructorPattern
   >(pattern);
   if (constructor_pattern) {
     for (auto &parameter : *(constructor_pattern->parameters)) {

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -14,9 +14,9 @@ Poi::Value::~Value() {
 ///////////////////////////////////////////////////////////////////////////////
 
 Poi::FunctionValue::FunctionValue(
-  std::shared_ptr<Poi::Function> function,
+  std::shared_ptr<const Poi::Function> function,
   std::shared_ptr<
-    std::unordered_map<size_t, std::shared_ptr<Poi::Value>>
+    const std::unordered_map<size_t, std::shared_ptr<const Poi::Value>>
   > captures
 ) : function(function), captures(captures) {
 }
@@ -30,7 +30,7 @@ std::string Poi::FunctionValue::show(const Poi::StringPool &pool) const {
 ///////////////////////////////////////////////////////////////////////////////
 
 Poi::DataTypeValue::DataTypeValue(
-  std::shared_ptr<Poi::DataType> data_type
+  std::shared_ptr<const Poi::DataType> data_type
 ) : data_type(data_type) {
 }
 
@@ -43,10 +43,10 @@ std::string Poi::DataTypeValue::show(const Poi::StringPool &pool) const {
 ///////////////////////////////////////////////////////////////////////////////
 
 Poi::DataValue::DataValue(
-  std::shared_ptr<Poi::DataType> type,
+  std::shared_ptr<const Poi::DataType> type,
   std::size_t constructor,
   std::shared_ptr<
-    std::unordered_map<size_t, std::shared_ptr<Poi::Value>>
+    const std::unordered_map<size_t, std::shared_ptr<const Poi::Value>>
   > captures
 ) : type(type), constructor(constructor), captures(captures) {
 }
@@ -65,7 +65,7 @@ std::string Poi::DataValue::show(const Poi::StringPool &pool) const {
 ///////////////////////////////////////////////////////////////////////////////
 
 Poi::ProxyValue::ProxyValue(
-  std::shared_ptr<Poi::Value> value
+  std::shared_ptr<const Poi::Value> value
 ) : value(value) {
 }
 


### PR DESCRIPTION
Previously, only the outside of every type was declared `const`. For example:

```c++
const std::shared_ptr<std::unordered_set<size_t>> free_variables;
```

This PR adds `const` to all the "inner" types. So the above becomes:

```c++
const std::shared_ptr<const std::unordered_set<size_t>> free_variables;
```

Note that we do not need to add `const` to `size_t` in this example, because `const` on the container type implies `const` on the members (attempting to mutate a member will raise a compiler error). In some cases, we cannot even add an explicit `const` to the member type, because the implementation of the container must be able to move elements around internally (e.g., to resize a vector).

**Status:** Ready

**Fixes:** N/A
