### PR TITLE
Remove some unnecessary forward declarations

### DIFF
--- a/include/value.h
+++ b/include/value.h
@@ -6,15 +6,12 @@
 #define POI_VALUE_H
 
 #include <memory>
+#include <poi/ast.h>
 #include <poi/string_pool.h>
 #include <string>
 #include <unordered_map>
 
 namespace Poi {
-  // Forward declarations to avoid mutually recursive headers
-  class Function; // Declared in poi/ast.h
-  class DataType; // Declared in poi/ast.h
-
   class Value {
   public:
     virtual ~Value();


### PR DESCRIPTION
Remove some unnecessary forward declarations in `value.h`.

We have a situation where `value.h` and `ast.h` depend on each other. To resolve this, we had neither `include` the other, and used forward references to achieve the mutual dependency. But this is only necessary in one direction. After this PR, `value.h` `include`s `ast.h`, but not the other way around. Only `ast.h` needs a forward declaration.

**Status:** Ready

**Fixes:** N/A
