### PR TITLE
Remove the unnecessary 'data' keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ Bindings:
 
 Algebraic data types and pattern matching:
 
-    bool = data {true, false}
+    bool = {true, false}
     not = x -> match x {
       {true} -> bool.false
       {false} -> bool.true
     }
 
-    option = data {none, some value}
+    option = {none, some value}
     map = f -> x -> match x {
       {none} -> option.none
       {some value} -> option.some (f value)

--- a/include/token.h
+++ b/include/token.h
@@ -13,7 +13,6 @@
 namespace Poi {
   enum class TokenType {
     ARROW,
-    DATA,
     DOT,
     EQUALS,
     IDENTIFIER,
@@ -27,7 +26,6 @@ namespace Poi {
 
   const char * const TokenTypeName[] = {
     "ARROW",
-    "DATA",
     "DOT",
     "EQUALS",
     "IDENTIFIER",

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -505,7 +505,7 @@ Poi::DataType::DataType(
 }
 
 std::string Poi::DataType::show(const Poi::StringPool &pool) const {
-  std::string result = "data {";
+  std::string result = "{";
   for (
     auto iter = constructor_names->begin();
     iter != constructor_names->end();

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -128,17 +128,7 @@ Poi::TokenStream Poi::tokenize(
       }
       size_t length = end_pos - pos;
       auto literal = source_str.substr(pos, length);
-      if (literal == "data") {
-        tokens.push_back(Token(
-          TokenType::DATA,
-          pool.insert(literal),
-          source_name,
-          source,
-          pos,
-          end_pos,
-          false
-        ));
-      } else if (literal == "match") {
+      if (literal == "match") {
         tokens.push_back(Token(
           TokenType::MATCH,
           pool.insert(literal),

--- a/tests/abstraction_pattern.json
+++ b/tests/abstraction_pattern.json
@@ -1,5 +1,5 @@
 {
-  "source": "option = data {none, some value}, ({some x} -> x) (option.some (x -> x))",
+  "source": "option = {none, some value}, ({some x} -> x) (option.some (x -> x))",
   "stdout": "(x -> x)\n",
   "stderr": "",
   "exit_code": 0

--- a/tests/bool.json
+++ b/tests/bool.json
@@ -1,6 +1,6 @@
 {
-  "source": "data {true, false}",
-  "stdout": "data {true, false}\n",
+  "source": "{true, false}",
+  "stdout": "{true, false}\n",
   "stderr": "",
   "exit_code": 0
 }

--- a/tests/constructor_function.json
+++ b/tests/constructor_function.json
@@ -1,5 +1,5 @@
 {
-  "source": "option = data {none, some value}, option.some (x -> x)",
+  "source": "option = {none, some value}, option.some (x -> x)",
   "stdout": "(some (x -> x))\n",
   "stderr": "",
   "exit_code": 0

--- a/tests/constructor_value.json
+++ b/tests/constructor_value.json
@@ -1,5 +1,5 @@
 {
-  "source": "option = data {none, some value}, option.none",
+  "source": "option = {none, some value}, option.none",
   "stdout": "(none)\n",
   "stderr": "",
   "exit_code": 0

--- a/tests/duplicate_constructor.json
+++ b/tests/duplicate_constructor.json
@@ -1,5 +1,5 @@
 {
-  "source": "data {some, some value}",
+  "source": "{some, some value}",
   "stdout": "",
   "exit_code": 1
 }

--- a/tests/duplicate_parameter_in_constructor.json
+++ b/tests/duplicate_parameter_in_constructor.json
@@ -1,5 +1,5 @@
 {
-  "source": "data {foo x x}",
+  "source": "{foo x x}",
   "stdout": "",
   "exit_code": 1
 }

--- a/tests/let_pattern.json
+++ b/tests/let_pattern.json
@@ -1,5 +1,5 @@
 {
-  "source": "option = data {none, some value}, a = option.some (x -> x), {some b} = a, b",
+  "source": "option = {none, some value}, a = option.some (x -> x), {some b} = a, b",
   "stdout": "(x -> x)\n",
   "stderr": "",
   "exit_code": 0

--- a/tests/map.json
+++ b/tests/map.json
@@ -1,5 +1,5 @@
 {
-  "source": "bool = data {true, false}, not = x -> match x {{true} -> bool.false, {false} -> bool.true}, option = data {none, some value}, map = f -> x -> match x {{none} -> option.none, {some value} -> option.some (f value)}, map not (option.some bool.false)",
+  "source": "bool = {true, false}, not = x -> match x {{true} -> bool.false, {false} -> bool.true}, option = {none, some value}, map = f -> x -> match x {{none} -> option.none, {some value} -> option.some (f value)}, map not (option.some bool.false)",
   "stdout": "(some (true))\n",
   "stderr": "",
   "exit_code": 0

--- a/tests/match.json
+++ b/tests/match.json
@@ -1,5 +1,5 @@
 {
-  "source": "bool = data {true, false}, not = x -> match x {{true} -> bool.false, {false} -> bool.true}, not bool.false",
+  "source": "bool = {true, false}, not = x -> match x {{true} -> bool.false, {false} -> bool.true}, not bool.false",
   "stdout": "(true)\n",
   "stderr": "",
   "exit_code": 0

--- a/tests/match_error.json
+++ b/tests/match_error.json
@@ -1,5 +1,5 @@
 {
-  "source": "option = data {none, some value}, {none} = x -> x, x -> x",
+  "source": "option = {none, some value}, {none} = x -> x, x -> x",
   "stdout": "",
   "exit_code": 1
 }

--- a/tests/maybe.json
+++ b/tests/maybe.json
@@ -1,6 +1,6 @@
 {
-  "source": "data {none, some value}",
-  "stdout": "data {none, some value}\n",
+  "source": "{none, some value}",
+  "stdout": "{none, some value}\n",
   "stderr": "",
   "exit_code": 0
 }

--- a/tests/member.json
+++ b/tests/member.json
@@ -1,5 +1,5 @@
 {
-  "source": "option = data {none, some value}, m = option.some (x -> x), m.value",
+  "source": "option = {none, some value}, m = option.some (x -> x), m.value",
   "stdout": "(x -> x)\n",
   "stderr": "",
   "exit_code": 0

--- a/tests/nat.json
+++ b/tests/nat.json
@@ -1,5 +1,5 @@
 {
-  "source": "nat = data {zero, succ n}, add = x -> y -> match x {{zero} -> y, {succ n} -> nat.succ (add n y)}, two = nat.succ (nat.succ nat.zero), three = nat.succ (nat.succ (nat.succ nat.zero)), add two three",
+  "source": "nat = {zero, succ n}, add = x -> y -> match x {{zero} -> y, {succ n} -> nat.succ (add n y)}, two = nat.succ (nat.succ nat.zero), three = nat.succ (nat.succ (nat.succ nat.zero)), add two three",
   "stdout": "(succ (succ (succ (succ (succ (zero))))))\n",
   "stderr": "",
   "exit_code": 0

--- a/tests/nested_member.json
+++ b/tests/nested_member.json
@@ -1,5 +1,5 @@
 {
-  "source": "option = data {none, some value}, m = option.some (option.some (x -> x)), m.value.value",
+  "source": "option = {none, some value}, m = option.some (option.some (x -> x)), m.value.value",
   "stdout": "(x -> x)\n",
   "stderr": "",
   "exit_code": 0

--- a/tests/tree.json
+++ b/tests/tree.json
@@ -1,5 +1,5 @@
 {
-  "source": "tree = data {empty, node left value right}, tree.node (x -> x) (y -> y) (z -> z)",
+  "source": "tree = {empty, node left value right}, tree.node (x -> x) (y -> y) (z -> z)",
   "stdout": "(node (x -> x) (y -> y) (z -> z))\n",
   "stderr": "",
   "exit_code": 0

--- a/tests/type_error.json
+++ b/tests/type_error.json
@@ -1,5 +1,5 @@
 {
-  "source": "bool = data {true, false}, bool bool",
+  "source": "bool = {true, false}, bool bool",
   "stdout": "",
   "exit_code": 1
 }

--- a/tests/unit.json
+++ b/tests/unit.json
@@ -1,6 +1,6 @@
 {
-  "source": "data {unit}",
-  "stdout": "data {unit}\n",
+  "source": "{unit}",
+  "stdout": "{unit}\n",
   "stderr": "",
   "exit_code": 0
 }

--- a/tests/void.json
+++ b/tests/void.json
@@ -1,6 +1,6 @@
 {
-  "source": "data {}",
-  "stdout": "data {}\n",
+  "source": "{}",
+  "stdout": "{}\n",
   "stderr": "",
   "exit_code": 0
 }


### PR DESCRIPTION
Remove the unnecessary `data` keyword. The grammar is still unambiguous without it. Now we can write:

```
bool = {true, false}
```

That's probably about as minimal as we can get. 😄 

**Status:** Ready

**Fixes:** N/A
