### PR TITLE
Fix the grammar for match expressions

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -35,8 +35,8 @@
     Group = LEFT_PAREN Term RIGHT_PAREN
     Pattern = IDENTIFIER | LEFT_CURLY IDENTIFIER PatternList RIGHT_CURLY
     PatternList = | Pattern PatternList
-    Match = MATCH Term SEPARATOR LEFT_CURLY CaseList RIGHT_CURLY
-    CaseList = | Function CaseListTail
+    Match = MATCH Term LEFT_CURLY CaseList RIGHT_CURLY
+    CaseList = Function CaseListTail
     CaseListTail = | SEPARATOR Function CaseListTail
 
   There are two problems with the grammar above: the Application and Member
@@ -1901,6 +1901,22 @@ Poi::ParseResult<Poi::Match> parse_match(
     );
     cases->push_back(c.node);
     iter = c.next;
+  }
+
+  // Make sure we have at least one case.
+  if (cases->empty()) {
+    return memo_error<Poi::Match>(
+      memo,
+      key,
+      std::make_shared<Poi::ParseError>(
+        "A match expression must have at least one case.",
+        pool.find(start->source_name),
+        pool.find(start->source),
+        start->start_pos,
+        iter->end_pos,
+        Poi::ErrorConfidence::HIGH
+      )
+    );
   }
 
   // Skip the closing RIGHT_CURLY.


### PR DESCRIPTION
Fix the grammar for match expressions. There were two problems:

1. In the grammar, we have a `SEPARATOR` between the discriminee and the cases. The parser does not expect any `SEPARATOR` there. So I removed it from the grammar.
2. Removing the `SEPARATOR` actually revealed an ambiguity in the grammar:

```
Found a sentential form with two different derivations:

  MATCH Variable LEFT_CURLY RIGHT_CURLY LEFT_CURLY RIGHT_CURLY

Derivation 1:

  0: Term
  1: Match
  2: MATCH Term LEFT_CURLY CaseList RIGHT_CURLY
  3: MATCH Application LEFT_CURLY CaseList RIGHT_CURLY
  4: MATCH Term1 Term2 LEFT_CURLY CaseList RIGHT_CURLY
  5: MATCH Variable Term2 LEFT_CURLY CaseList RIGHT_CURLY
  6: MATCH Variable DataType LEFT_CURLY CaseList RIGHT_CURLY
  7: MATCH Variable LEFT_CURLY DataConstructorList RIGHT_CURLY LEFT_CURLY CaseList RIGHT_CURLY
  8: MATCH Variable LEFT_CURLY RIGHT_CURLY LEFT_CURLY CaseList RIGHT_CURLY
  9: MATCH Variable LEFT_CURLY RIGHT_CURLY LEFT_CURLY RIGHT_CURLY

Derivation 2:

  0: Term
  1: Application
  2: Term1 Term2
  3: Match Term2
  4: MATCH Term LEFT_CURLY CaseList RIGHT_CURLY Term2
  5: MATCH Variable LEFT_CURLY CaseList RIGHT_CURLY Term2
  6: MATCH Variable LEFT_CURLY RIGHT_CURLY Term2
  7: MATCH Variable LEFT_CURLY RIGHT_CURLY DataType
  8: MATCH Variable LEFT_CURLY RIGHT_CURLY LEFT_CURLY DataConstructorList RIGHT_CURLY
  9: MATCH Variable LEFT_CURLY RIGHT_CURLY LEFT_CURLY RIGHT_CURLY
```

To fix this, I changed the grammar to require at least one case in `match` expressions. Why would anyone have a `match` with no cases?

**Status:** Ready

**Fixes:** N/A
