### PR TITLE
Optimize constructor references by precomputing them

### DIFF
--- a/include/ast.h
+++ b/include/ast.h
@@ -238,7 +238,7 @@ namespace Poi {
   // syntax for Data terms.
   class Data : public Term {
   public:
-    const std::weak_ptr<const Poi::DataType> type;
+    const std::weak_ptr<const Poi::DataType> data_type;
     const size_t constructor;
 
     explicit Data(
@@ -247,7 +247,7 @@ namespace Poi {
       size_t start_pos,
       size_t end_pos,
       std::shared_ptr<const std::unordered_set<size_t>> free_variables,
-      std::weak_ptr<const Poi::DataType> type,
+      std::weak_ptr<const Poi::DataType> data_type,
       size_t constructor
     );
     std::string show(const Poi::StringPool &pool) const override;

--- a/include/value.h
+++ b/include/value.h
@@ -37,27 +37,33 @@ namespace Poi {
   class DataTypeValue : public Value {
   public:
     const std::shared_ptr<const Poi::DataType> data_type;
+    const std::shared_ptr<
+      const std::unordered_map<size_t, std::shared_ptr<const Poi::Value>>
+    > constructors;
 
     explicit DataTypeValue(
-      std::shared_ptr<const Poi::DataType> data_type
+      std::shared_ptr<const Poi::DataType> data_type,
+      const std::shared_ptr<
+        const std::unordered_map<size_t, std::shared_ptr<const Poi::Value>>
+      > constructors
     );
     std::string show(const Poi::StringPool &pool) const override;
   };
 
   class DataValue : public Value {
   public:
-    const std::shared_ptr<const Poi::DataType> type;
+    const std::shared_ptr<const Poi::DataType> data_type;
     const std::size_t constructor;
     const std::shared_ptr<
       const std::unordered_map<size_t, std::shared_ptr<const Poi::Value>>
-    > captures;
+    > members;
 
     explicit DataValue(
       std::shared_ptr<const Poi::DataType> type,
       std::size_t constructor,
       std::shared_ptr<
         const std::unordered_map<size_t, std::shared_ptr<const Poi::Value>>
-      > captures
+      > members
     );
     std::string show(const Poi::StringPool &pool) const override;
   };

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1572,7 +1572,7 @@ Poi::ParseResult<Poi::DataType> parse_data_type(
   // "Tie the knot" by giving the Data terms a reference to the DataType.
   for (auto &data_term : data_terms) {
     const_cast<std::weak_ptr<const Poi::DataType> &>(
-      data_term->type
+      data_term->data_type
     ) = std::weak_ptr<const Poi::DataType>(data_type);
   }
 

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -30,8 +30,11 @@ std::string Poi::FunctionValue::show(const Poi::StringPool &pool) const {
 ///////////////////////////////////////////////////////////////////////////////
 
 Poi::DataTypeValue::DataTypeValue(
-  std::shared_ptr<const Poi::DataType> data_type
-) : data_type(data_type) {
+  std::shared_ptr<const Poi::DataType> data_type,
+  const std::shared_ptr<
+    const std::unordered_map<size_t, std::shared_ptr<const Poi::Value>>
+  > constructors
+) : data_type(data_type), constructors(constructors) {
 }
 
 std::string Poi::DataTypeValue::show(const Poi::StringPool &pool) const {
@@ -43,18 +46,18 @@ std::string Poi::DataTypeValue::show(const Poi::StringPool &pool) const {
 ///////////////////////////////////////////////////////////////////////////////
 
 Poi::DataValue::DataValue(
-  std::shared_ptr<const Poi::DataType> type,
+  std::shared_ptr<const Poi::DataType> data_type,
   std::size_t constructor,
   std::shared_ptr<
     const std::unordered_map<size_t, std::shared_ptr<const Poi::Value>>
-  > captures
-) : type(type), constructor(constructor), captures(captures) {
+  > members
+) : data_type(data_type), constructor(constructor), members(members) {
 }
 
 std::string Poi::DataValue::show(const Poi::StringPool &pool) const {
   std::string result = "(" + pool.find(constructor);
-  for (auto &capture : *captures) {
-    result += " " + capture.second->show(pool);
+  for (auto &member : *members) {
+    result += " " + member.second->show(pool);
   }
   result += ")";
   return result;


### PR DESCRIPTION
Previously, we would construct a `Value` for a constructor whenever it was referenced. Now we preallocate all of the constructors when the type is created.

Before:

```
option = {none, some value} # Constructors don't exist as values yet
option.some # Function created here
```

After:

```
option = {none, some value} # Both constructors created here
option.some # Function already exists, just return it
```

**Status:** Ready

**Fixes:** N/A
