### PR TITLE
Implement tail call optimization

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -118,7 +118,11 @@ int main(int argc, char *argv[]) {
 
     // Evaluate the program.
     std::unordered_map<size_t, std::shared_ptr<const Poi::Value>> environment;
-    auto value = term->eval(term, environment, pool);
+    auto value = Poi::trampoline(
+      term->eval(term, environment, pool, 0),
+      pool,
+      0
+    );
     std::cout << value->show(pool) << "\n";
   } catch(Poi::Error &e) {
     // There was an error. Print it and exit.

--- a/include/ast.h
+++ b/include/ast.h
@@ -99,7 +99,8 @@ namespace Poi {
       const std::unordered_map<
         size_t, std::shared_ptr<const Poi::Value>
       > &environment,
-      const Poi::StringPool &pool
+      const Poi::StringPool &pool,
+      size_t depth
     ) const = 0;
   };
 
@@ -121,7 +122,8 @@ namespace Poi {
       const std::unordered_map<
         size_t, std::shared_ptr<const Poi::Value>
       > &environment,
-      const Poi::StringPool &pool
+      const Poi::StringPool &pool,
+      size_t depth
     ) const override;
   };
 
@@ -145,7 +147,8 @@ namespace Poi {
       const std::unordered_map<
         size_t, std::shared_ptr<const Poi::Value>
       > &environment,
-      const Poi::StringPool &pool
+      const Poi::StringPool &pool,
+      size_t depth
     ) const override;
   };
 
@@ -169,7 +172,8 @@ namespace Poi {
       const std::unordered_map<
         size_t, std::shared_ptr<const Poi::Value>
       > &environment,
-      const Poi::StringPool &pool
+      const Poi::StringPool &pool,
+      size_t depth
     ) const override;
   };
 
@@ -195,7 +199,8 @@ namespace Poi {
       const std::unordered_map<
         size_t, std::shared_ptr<const Poi::Value>
       > &environment,
-      const Poi::StringPool &pool
+      const Poi::StringPool &pool,
+      size_t depth
     ) const override;
   };
 
@@ -229,7 +234,8 @@ namespace Poi {
       const std::unordered_map<
         size_t, std::shared_ptr<const Poi::Value>
       > &environment,
-      const Poi::StringPool &pool
+      const Poi::StringPool &pool,
+      size_t depth
     ) const override;
   };
 
@@ -256,7 +262,8 @@ namespace Poi {
       const std::unordered_map<
         size_t, std::shared_ptr<const Poi::Value>
       > &environment,
-      const Poi::StringPool &pool
+      const Poi::StringPool &pool,
+      size_t depth
     ) const override;
   };
 
@@ -285,7 +292,8 @@ namespace Poi {
       const std::unordered_map<
         size_t, std::shared_ptr<const Poi::Value>
       > &environment,
-      const Poi::StringPool &pool
+      const Poi::StringPool &pool,
+      size_t depth
     ) const override;
   };
 
@@ -313,7 +321,8 @@ namespace Poi {
       const std::unordered_map<
         size_t, std::shared_ptr<const Poi::Value>
       > &environment,
-      const Poi::StringPool &pool
+      const Poi::StringPool &pool,
+      size_t depth
     ) const override;
   };
 }

--- a/include/value.h
+++ b/include/value.h
@@ -78,6 +78,30 @@ namespace Poi {
     );
     std::string show(const Poi::StringPool &pool) const override;
   };
+
+  // Used to implement tail recursion
+  class ThunkValue : public Value {
+  public:
+    const std::shared_ptr<const Poi::Term> term;
+    const std::shared_ptr<
+      const std::unordered_map<size_t, std::shared_ptr<const Poi::Value>>
+    > environment;
+
+    explicit ThunkValue(
+      std::shared_ptr<const Poi::Term> term,
+      std::shared_ptr<
+        const std::unordered_map<size_t, std::shared_ptr<const Poi::Value>>
+      > environment
+    );
+    std::string show(const Poi::StringPool &pool) const override;
+  };
+
+  // Repeatedly evaluate a Poi::Value until it is no longer a Poi::ThunkValue.
+  std::shared_ptr<const Poi::Value> trampoline(
+    std::shared_ptr<const Poi::Value> value,
+    const Poi::StringPool &pool,
+    size_t depth
+  );
 }
 
 #endif


### PR DESCRIPTION
Implement tail call optimization using the trampoline technique.

Now infinite tail calls actually cause the program to loop forever rather than segfault:

```
# This loops forever
f = x -> f x
f (y -> y)
```

Also, we now have a maximum recursion depth for non-tail calls:

```
f = x -> (y -> y) (f x)
f (z -> z)

# Error: Maximum recursion depth exceeded.
# Location: example.poi @ 1:20
# 
# f = x -> (y -> y) (f x)
#                    ^
```

**Status:** Ready

**Fixes:** N/A
