### PR TITLE
Show stack traces when an evaluation error happens

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -118,10 +118,11 @@ int main(int argc, char *argv[]) {
 
     // Evaluate the program.
     std::unordered_map<size_t, std::shared_ptr<const Poi::Value>> environment;
+    std::vector<std::shared_ptr<const Poi::Term>> stack_trace;
     auto value = Poi::trampoline(
-      term->eval(term, environment, pool, 0),
-      pool,
-      0
+      term->eval(term, environment, stack_trace, pool),
+      stack_trace,
+      pool
     );
     std::cout << value->show(pool) << "\n";
   } catch(Poi::Error &e) {

--- a/include/error.h
+++ b/include/error.h
@@ -8,9 +8,20 @@
 #include <string>
 
 namespace Poi {
+  std::string get_location(
+    const std::string &source_name,
+    const std::string &source,
+    size_t start_pos, // Inclusive
+    size_t end_pos // Exclusive
+  );
+
   class Error {
   private:
     std::string message;
+
+  protected:
+    explicit Error();
+    void update(const std::string &message);
 
   public:
     explicit Error(

--- a/include/parser.h
+++ b/include/parser.h
@@ -12,9 +12,9 @@
 
 namespace Poi {
   // Parse a stream of tokens.
-  std::shared_ptr<const Poi::Term> parse(
-    const Poi::TokenStream &token_stream,
-    const Poi::StringPool &pool
+  std::shared_ptr<const Term> parse(
+    const TokenStream &token_stream,
+    const StringPool &pool
   );
 }
 

--- a/include/token.h
+++ b/include/token.h
@@ -39,7 +39,7 @@ namespace Poi {
 
   class Token {
   public:
-    const Poi::TokenType type;
+    const TokenType type;
     const size_t literal;
     const size_t source_name;
     const size_t source;
@@ -49,7 +49,7 @@ namespace Poi {
     const bool explicit_separator; // Only used for SEPARATOR tokens
 
     explicit Token(
-      Poi::TokenType type,
+      TokenType type,
       size_t literal,
       size_t source_name,
       size_t source,
@@ -57,19 +57,19 @@ namespace Poi {
       size_t end_pos,
       bool explicit_separator
     );
-    std::string show(Poi::StringPool &pool) const;
+    std::string show(StringPool &pool) const;
   };
 
   class TokenStream {
   public:
     const size_t source_name;
     const size_t source;
-    const std::shared_ptr<const std::vector<Poi::Token>> tokens;
+    const std::shared_ptr<const std::vector<Token>> tokens;
 
     explicit TokenStream(
       size_t source_name,
       size_t source,
-      std::shared_ptr<const std::vector<Poi::Token>> tokens
+      std::shared_ptr<const std::vector<Token>> tokens
     );
   };
 }

--- a/include/tokenizer.h
+++ b/include/tokenizer.h
@@ -11,11 +11,7 @@
 namespace Poi {
   // Perform lexical analysis. The tokenizer guarantees that all LEFT_*/RIGHT_*
   // tokens will be matched in the returned stream.
-  Poi::TokenStream tokenize(
-    size_t source_name,
-    size_t source,
-    Poi::StringPool &pool
-  );
+  TokenStream tokenize(size_t source_name, size_t source, StringPool &pool);
 }
 
 #endif

--- a/include/value.h
+++ b/include/value.h
@@ -15,92 +15,90 @@ namespace Poi {
   class Value {
   public:
     virtual ~Value();
-    virtual std::string show(const Poi::StringPool &pool) const = 0;
+    virtual std::string show(const StringPool &pool) const = 0;
   };
 
   class FunctionValue : public Value {
   public:
-    const std::shared_ptr<const Poi::Function> function;
+    const std::shared_ptr<const Function> function;
     const std::shared_ptr<
-      const std::unordered_map<size_t, std::shared_ptr<const Poi::Value>>
+      const std::unordered_map<size_t, std::shared_ptr<const Value>>
     > captures;
 
     explicit FunctionValue(
-      std::shared_ptr<const Poi::Function> function,
+      std::shared_ptr<const Function> function,
       std::shared_ptr<
-        const std::unordered_map<size_t, std::shared_ptr<const Poi::Value>>
+        const std::unordered_map<size_t, std::shared_ptr<const Value>>
       > captures
     );
-    std::string show(const Poi::StringPool &pool) const override;
+    std::string show(const StringPool &pool) const override;
   };
 
   class DataTypeValue : public Value {
   public:
-    const std::shared_ptr<const Poi::DataType> data_type;
+    const std::shared_ptr<const DataType> data_type;
     const std::shared_ptr<
-      const std::unordered_map<size_t, std::shared_ptr<const Poi::Value>>
+      const std::unordered_map<size_t, std::shared_ptr<const Value>>
     > constructors;
 
     explicit DataTypeValue(
-      std::shared_ptr<const Poi::DataType> data_type,
+      std::shared_ptr<const DataType> data_type,
       const std::shared_ptr<
-        const std::unordered_map<size_t, std::shared_ptr<const Poi::Value>>
+        const std::unordered_map<size_t, std::shared_ptr<const Value>>
       > constructors
     );
-    std::string show(const Poi::StringPool &pool) const override;
+    std::string show(const StringPool &pool) const override;
   };
 
   class DataValue : public Value {
   public:
-    const std::shared_ptr<const Poi::DataType> data_type;
+    const std::shared_ptr<const DataType> data_type;
     const std::size_t constructor;
     const std::shared_ptr<
-      const std::unordered_map<size_t, std::shared_ptr<const Poi::Value>>
+      const std::unordered_map<size_t, std::shared_ptr<const Value>>
     > members;
 
     explicit DataValue(
-      std::shared_ptr<const Poi::DataType> type,
+      std::shared_ptr<const DataType> type,
       std::size_t constructor,
       std::shared_ptr<
-        const std::unordered_map<size_t, std::shared_ptr<const Poi::Value>>
+        const std::unordered_map<size_t, std::shared_ptr<const Value>>
       > members
     );
-    std::string show(const Poi::StringPool &pool) const override;
+    std::string show(const StringPool &pool) const override;
   };
 
   // Used to "tie the knot" for recursive bindings
   class ProxyValue : public Value {
   public:
-    const std::shared_ptr<const Poi::Value> value;
+    const std::shared_ptr<const Value> value;
 
-    explicit ProxyValue(
-      std::shared_ptr<const Poi::Value> value
-    );
-    std::string show(const Poi::StringPool &pool) const override;
+    explicit ProxyValue(std::shared_ptr<const Value> value);
+    std::string show(const StringPool &pool) const override;
   };
 
   // Used to implement tail recursion
   class ThunkValue : public Value {
   public:
-    const std::shared_ptr<const Poi::Term> term;
+    const std::shared_ptr<const Term> term;
     const std::shared_ptr<
-      const std::unordered_map<size_t, std::shared_ptr<const Poi::Value>>
+      const std::unordered_map<size_t, std::shared_ptr<const Value>>
     > environment;
 
     explicit ThunkValue(
-      std::shared_ptr<const Poi::Term> term,
+      std::shared_ptr<const Term> term,
       std::shared_ptr<
-        const std::unordered_map<size_t, std::shared_ptr<const Poi::Value>>
+        const std::unordered_map<size_t, std::shared_ptr<const Value>>
       > environment
     );
-    std::string show(const Poi::StringPool &pool) const override;
+    std::string show(const StringPool &pool) const override;
   };
 
-  // Repeatedly evaluate a Poi::Value until it is no longer a Poi::ThunkValue.
-  std::shared_ptr<const Poi::Value> trampoline(
-    std::shared_ptr<const Poi::Value> value,
-    const Poi::StringPool &pool,
-    size_t depth
+  // Repeatedly evaluate a Value until it is no longer a ThunkValue.
+  std::shared_ptr<const Value> trampoline(
+    std::shared_ptr<const Value> value,
+    std::vector<std::shared_ptr<const Term>> &stack_trace,
+    const StringPool &pool
   );
 }
 

--- a/src/string_pool.cpp
+++ b/src/string_pool.cpp
@@ -21,7 +21,7 @@ size_t Poi::StringPool::insert(const std::string &s) {
 std::string Poi::StringPool::find(size_t id) const {
   auto iter = reverse_pool.find(id);
   if (iter == reverse_pool.end()) {
-    throw Poi::Error(
+    throw Error(
       "'" + std::to_string(id) + "' is not in the string pool."
     );
   } else {

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -8,20 +8,18 @@
 
 std::shared_ptr<const Poi::Value> Poi::trampoline(
   std::shared_ptr<const Poi::Value> value,
-  const Poi::StringPool &pool,
-  size_t depth
+  std::vector<std::shared_ptr<const Poi::Term>> &stack_trace,
+  const Poi::StringPool &pool
 ) {
   auto result = value;
   while (true) {
-    auto thunk_value = std::dynamic_pointer_cast<
-      const Poi::ThunkValue
-    >(result);
+    auto thunk_value = std::dynamic_pointer_cast<const ThunkValue>(result);
     if (thunk_value) {
       result = thunk_value->term->eval(
         thunk_value->term,
         *(thunk_value->environment),
-        pool,
-        depth
+        stack_trace,
+        pool
       );
     } else {
       break;
@@ -104,7 +102,7 @@ std::string Poi::ProxyValue::show(const Poi::StringPool &pool) const {
   if (value) {
     return value->show(pool);
   } else {
-    throw Poi::Error("Undefined.");
+    throw Error("Undefined.");
   }
 }
 


### PR DESCRIPTION
Show stack traces when an evaluation error happens. Some differences between Poi's stack traces and those of other programming languages:

- Poi does tail call elimination, which means those stack frames disappear. That makes stack traces less useful in general, sadly.
- Poi's stack traces include a separate frame for every AST node currently being evaluated (except those in tail position, as noted above), rather than just the distinct lines.
- For each frame, Poi provides not only the relevant line numbers but also the relevant column numbers.

Example program:

```
bool = {true, false}
not = x -> match x {
  {true} -> bool.false
  {false} -> bool.true
}

option = {none, some value}
map = f -> x -> match x {
  {none} -> option.none
  {some value} -> option.some (f value)
}

(x -> x) (map not (option.some option.none))
```

Error:

```
Error: 'true' is not a constructor of {none, some value}.

example.poi @ 2:12 - 5:1
example.poi @ 10:19 - 10:39
example.poi @ 13:1 - 13:44
```

**Status:** Ready

**Fixes:** https://github.com/stepchowfun/poi/issues/70
