### PR TITLE
Hide frames corresponding to Binding expressions from stack traces

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -36,6 +36,12 @@ public:
       iter != stack_trace.rend();
       ++iter
     ) {
+      if (std::dynamic_pointer_cast<const Poi::Binding>(*iter)) {
+        // Don't show frames corresponding to Binding expressions, because
+        // those are not very helpful.
+        continue;
+      }
+
       new_message += "\n" + Poi::get_location(
         pool.find((*iter)->source_name),
         pool.find((*iter)->source),


### PR DESCRIPTION
Hide frames corresponding to `Binding` expressions from stack traces.

Example:

```
bool = {true, false}
not = x -> match x {
  {true} -> bool.false
  {false} -> bool.true
}

option = {none, some value}
map = f -> x -> match x {
  {none} -> option.none
  {some value} -> option.some (f value)
}

(x -> x) (map not (option.some option.none))
```

Before:

```
Error: 'true' is not a constructor of {none, some value}.

example.poi @ 2:12 - 5:1
example.poi @ 10:31 - 10:39
example.poi @ 10:19 - 10:39
example.poi @ 8:17 - 11:1
example.poi @ 13:10 - 13:44
example.poi @ 13:1 - 13:44
example.poi @ 8:1 - 13:44
example.poi @ 7:1 - 13:44
example.poi @ 2:1 - 13:44
example.poi @ 1:1 - 13:44
```

After:

```
Error: 'true' is not a constructor of {none, some value}.

example.poi @ 2:12 - 5:1
example.poi @ 10:31 - 10:39
example.poi @ 10:19 - 10:39
example.poi @ 8:17 - 11:1
example.poi @ 13:10 - 13:44
example.poi @ 13:1 - 13:44
```

**Status:** Ready

**Fixes:** N/A
