### PR TITLE
Make sure all global definitions except those in main.cpp are in the `Poi` namespace

### DIFF
--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -20,8 +20,8 @@ std::shared_ptr<Poi::BasicBlock> Poi::compile_ast_to_ir(
 std::shared_ptr<std::vector<Poi::Bytecode>> Poi::compile_ir_to_bc(
   const Poi::BasicBlock &basic_block
 ) {
-  std::vector<Poi::Bytecode> program;
-  auto bytecode = std::make_shared<std::vector<Poi::Bytecode>>();
+  std::vector<Bytecode> program;
+  auto bytecode = std::make_shared<std::vector<Bytecode>>();
   basic_block.emit_bytecode(program, *bytecode);
   std::ptrdiff_t offset = bytecode->size();
   bytecode->insert(bytecode->end(), program.begin(), program.end());

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -1,50 +1,52 @@
 #include <poi/error.h>
 
-void get_location_info(
-  const std::string &source_name,
-  const std::string &source,
-  std::size_t start_pos, // Inclusive
-  std::size_t end_pos, // Exclusive
-  std::size_t &start_line,
-  std::size_t &start_col,
-  std::size_t &end_line,
-  std::size_t &end_col,
-  std::size_t &context_start_pos,
-  std::size_t &context_end_pos
-) {
-  start_line = 0;
-  start_col = 0;
-  end_line = 0;
-  end_col = 0;
-  context_start_pos = 0;
-  context_end_pos = source.size();
-  std::size_t line_number = 0;
-  std::size_t col_number = 0;
-  bool found_start = false;
-  bool found_end = false;
-  for (std::size_t pos = 0; pos <= source.size(); ++pos) {
-    if (pos == start_pos) {
-      start_line = line_number;
-      start_col = col_number;
-      found_start = true;
-    }
-    if (pos == end_pos) {
-      end_line = line_number;
-      end_col = col_number;
-      found_end = true;
-    }
-    if (pos == source.size() || source[pos] == '\n') {
-      ++line_number;
-      col_number = 0;
-      if (!found_start) {
-        context_start_pos = pos + 1;
+namespace Poi {
+  void get_location_info(
+    const std::string &source_name,
+    const std::string &source,
+    std::size_t start_pos, // Inclusive
+    std::size_t end_pos, // Exclusive
+    std::size_t &start_line,
+    std::size_t &start_col,
+    std::size_t &end_line,
+    std::size_t &end_col,
+    std::size_t &context_start_pos,
+    std::size_t &context_end_pos
+  ) {
+    start_line = 0;
+    start_col = 0;
+    end_line = 0;
+    end_col = 0;
+    context_start_pos = 0;
+    context_end_pos = source.size();
+    std::size_t line_number = 0;
+    std::size_t col_number = 0;
+    bool found_start = false;
+    bool found_end = false;
+    for (std::size_t pos = 0; pos <= source.size(); ++pos) {
+      if (pos == start_pos) {
+        start_line = line_number;
+        start_col = col_number;
+        found_start = true;
       }
-      if (found_end) {
-        context_end_pos = pos;
-        break;
+      if (pos == end_pos) {
+        end_line = line_number;
+        end_col = col_number;
+        found_end = true;
       }
-    } else {
-      ++col_number;
+      if (pos == source.size() || source[pos] == '\n') {
+        ++line_number;
+        col_number = 0;
+        if (!found_start) {
+          context_start_pos = pos + 1;
+        }
+        if (found_end) {
+          context_end_pos = pos;
+          break;
+        }
+      } else {
+        ++col_number;
+      }
     }
   }
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -67,505 +67,344 @@
 
 */
 
-///////////////////////////////////////////////////////////////////////////////
-// Error handling                                                            //
-///////////////////////////////////////////////////////////////////////////////
+namespace Poi {
+  /////////////////////////////////////////////////////////////////////////////
+  // Error handling                                                          //
+  /////////////////////////////////////////////////////////////////////////////
 
-// If we encounter an error while parsing, we may backtrack and try a
-// different branch of execution. This may lead to more errors. If all the
-// branches lead to an error, we need to choose one of the errors to show to
-// the user. To pick the most relevant one, we assign each error a confidence
-// level.
-enum class ErrorConfidence {
-  LOW, // The error provides no useful information other than the fact that
-       // the parse failed. Hopefully another branch will succeed or fail with
-       // a more useful error.
-  MED, // The error provides some useful information about the failure, but we
-       // aren't 100% confident that this is the right error to show the user.
-       // Another branch may succeed or fail with a more useful error.
-  HIGH // This is definitely the error we will show to the user. We are so
-       // confident in this error that it actually takes precedence over a
-       // successful branch (because we would have received a failure later on
-       // anyway).
-};
-
-// This is just like Poi::Error, except it also includes a confidence level.
-class ParseError : public Poi::Error {
-public:
-  const ErrorConfidence confidence;
-
-  explicit ParseError(
-    const std::string &message, // No trailing line break
-    ErrorConfidence confidence
-  ) : Error(message), confidence(confidence) {
+  // If we encounter an error while parsing, we may backtrack and try a
+  // different branch of execution. This may lead to more errors. If all the
+  // branches lead to an error, we need to choose one of the errors to show to
+  // the user. To pick the most relevant one, we assign each error a confidence
+  // level.
+  enum class ErrorConfidence {
+    LOW, // The error provides no useful information other than the fact that
+         // the parse failed. Hopefully another branch will succeed or fail
+         // with a more useful error.
+    MED, // The error provides some useful information about the failure, but
+         // we aren't 100% confident that this is the right error to show the
+         // user. Another branch may succeed or fail with a more useful error.
+    HIGH // This is definitely the error we will show to the user. We are so
+         // confident in this error that it actually takes precedence over a
+         // successful branch (because we would have received a failure later
+         // on anyway).
   };
 
-  explicit ParseError(
-    const std::string &message, // No trailing line break
-    const std::string &source_name,
-    const std::string &source,
-    ErrorConfidence confidence
-  ) :
-    Error (message, source_name, source),
-    confidence(confidence) {
+  // This is just like Poi::Error, except it also includes a confidence level.
+  class ParseError : public Error {
+  public:
+    const ErrorConfidence confidence;
+
+    explicit ParseError(
+      const std::string &message, // No trailing line break
+      ErrorConfidence confidence
+    ) : Error(message), confidence(confidence) {
+    };
+
+    explicit ParseError(
+      const std::string &message, // No trailing line break
+      const std::string &source_name,
+      const std::string &source,
+      ErrorConfidence confidence
+    ) :
+      Error (message, source_name, source),
+      confidence(confidence) {
+    };
+
+    explicit ParseError(
+      const std::string &message, // No trailing line break
+      const std::string &source_name,
+      const std::string &source,
+      std::size_t start_pos, // Inclusive
+      std::size_t end_pos, // Exclusive
+      ErrorConfidence confidence
+    ) :
+      Error (message, source_name, source, start_pos, end_pos),
+      confidence(confidence) {
+    };
   };
 
-  explicit ParseError(
-    const std::string &message, // No trailing line break
-    const std::string &source_name,
-    const std::string &source,
-    std::size_t start_pos, // Inclusive
-    std::size_t end_pos, // Exclusive
-    ErrorConfidence confidence
-  ) :
-    Error (message, source_name, source, start_pos, end_pos),
-    confidence(confidence) {
-  };
-};
+  // A successful parse results in an AST node and an iterator pointing to the
+  // next token to parse. A failed parse results in a ParseError.
+  template <typename T> class ParseResult {
+  public:
+    // Exactly one of these two should be a null pointer.
+    const std::shared_ptr<const T> node;
+    const std::shared_ptr<const ParseError> error;
 
-// A successful parse results in an AST node and an iterator pointing to the
-// next token to parse. A failed parse results in a ParseError.
-template <typename T> class ParseResult {
-public:
-  // Exactly one of these two should be a null pointer.
-  const std::shared_ptr<const T> node;
-  const std::shared_ptr<const ParseError> error;
+    // If `node` is present, this should point to the first token after `node`.
+    // Otherwise, its value is unspecified.
+    const std::vector<Token>::const_iterator next;
 
-  // If `node` is present, this should point to the first token after `node`.
-  // Otherwise, its value is unspecified.
-  const std::vector<Poi::Token>::const_iterator next;
-
-  // Success constructor
-  explicit ParseResult(
-    std::shared_ptr<const T> node,
-    std::vector<Poi::Token>::const_iterator next
-  ) : node(node), next(next) {
-  }
-
-  // Failure constructor
-  explicit ParseResult(
-    std::shared_ptr<const ParseError> error
-  ) : error(error) {
-  }
-
-  // Cast a ParseResult<T> to a ParseResult<U>, where T <: U
-  template <typename U> ParseResult<U> upcast() const {
-    if (node) {
-      return ParseResult<U>(std::static_pointer_cast<const U>(node), next);
-    } else {
-      return ParseResult<U>(error);
+    // Success constructor
+    explicit ParseResult(
+      std::shared_ptr<const T> node,
+      std::vector<Token>::const_iterator next
+    ) : node(node), next(next) {
     }
-  }
 
-  // Cast a ParseResult<T> to a ParseResult<U>, where U <: T
-  template <typename U> ParseResult<U> downcast() const {
-    if (node) {
-      return ParseResult<U>(std::dynamic_pointer_cast<const U>(node), next);
-    } else {
-      return ParseResult<U>(error);
+    // Failure constructor
+    explicit ParseResult(
+      std::shared_ptr<const ParseError> error
+    ) : error(error) {
     }
-  }
 
-  // Choose between this and another ParseResult. If one is a success and the
-  // other is an error, choose the success. If both are successes, choose the
-  // biggest node. If both are errors, choose based on the confidence.
-  ParseResult<T> choose(const ParseResult<T> &other) const {
-    if (error && error->confidence == ErrorConfidence::HIGH) {
-      return *this;
-    }
-    if (
-      other.error &&
-      other.error->confidence == ErrorConfidence::HIGH
-    ) {
-      return other;
-    }
-    if (node) {
-      if (other.node) {
-        if (other.node->end_pos > node->end_pos) {
-          return other;
-        } else {
-          return *this;
-        }
+    // Cast a ParseResult<T> to a ParseResult<U>, where T <: U
+    template <typename U> ParseResult<U> upcast() const {
+      if (node) {
+        return ParseResult<U>(std::static_pointer_cast<const U>(node), next);
       } else {
+        return ParseResult<U>(error);
+      }
+    }
+
+    // Cast a ParseResult<T> to a ParseResult<U>, where U <: T
+    template <typename U> ParseResult<U> downcast() const {
+      if (node) {
+        return ParseResult<U>(std::dynamic_pointer_cast<const U>(node), next);
+      } else {
+        return ParseResult<U>(error);
+      }
+    }
+
+    // Choose between this and another ParseResult. If one is a success and the
+    // other is an error, choose the success. If both are successes, choose the
+    // biggest node. If both are errors, choose based on the confidence.
+    ParseResult<T> choose(const ParseResult<T> &other) const {
+      if (error && error->confidence == ErrorConfidence::HIGH) {
         return *this;
       }
-    } else {
-      if (other.node) {
+      if (
+        other.error &&
+        other.error->confidence == ErrorConfidence::HIGH
+      ) {
         return other;
-      } else {
-        if (other.error->confidence > error->confidence) {
-          return other;
+      }
+      if (node) {
+        if (other.node) {
+          if (other.node->end_pos > node->end_pos) {
+            return other;
+          } else {
+            return *this;
+          }
         } else {
           return *this;
         }
+      } else {
+        if (other.node) {
+          return other;
+        } else {
+          if (other.error->confidence > error->confidence) {
+            return other;
+          } else {
+            return *this;
+          }
+        }
       }
     }
-  }
-};
+  };
 
-///////////////////////////////////////////////////////////////////////////////
-// Memoization                                                               //
-///////////////////////////////////////////////////////////////////////////////
+  /////////////////////////////////////////////////////////////////////////////
+  // Memoization                                                             //
+  /////////////////////////////////////////////////////////////////////////////
 
-// This enum represents the set of functions which memoize their result.
-enum class MemoType {
-  PATTERN,
-  VARIABLE_PATTERN,
-  CONSTRUCTOR_PATTERN,
-  TERM,
-  VARIABLE,
-  FUNCTION,
-  APPLICATION,
-  BINDING,
-  DATA_TYPE,
-  MEMBER,
-  MATCH,
-  GROUP
-};
+  // This enum represents the set of functions which memoize their result.
+  enum class MemoType {
+    PATTERN,
+    VARIABLE_PATTERN,
+    CONSTRUCTOR_PATTERN,
+    TERM,
+    VARIABLE,
+    FUNCTION,
+    APPLICATION,
+    BINDING,
+    DATA_TYPE,
+    MEMBER,
+    MATCH,
+    GROUP
+  };
 
-// The type of keys used in the memoization table
-using MemoKey = std::tuple<
-  MemoType, // Represents the function doing the memoizing
-  std::vector<Poi::Token>::const_iterator, // The start token
-  std::shared_ptr<const Poi::Term> // The `application_prior` term
->;
+  // The type of keys used in the memoization table
+  using MemoKey = std::tuple<
+    MemoType, // Represents the function doing the memoizing
+    std::vector<Token>::const_iterator, // The start token
+    std::shared_ptr<const Term> // The `application_prior` term
+  >;
 
-// The type of the memoization table
-using MemoMap = std::unordered_map<
-  MemoKey,
-  ParseResult<Poi::Node>,
-  std::function<std::size_t(const MemoKey &key)>
->;
+  // The type of the memoization table
+  using MemoMap = std::unordered_map<
+    MemoKey,
+    ParseResult<Node>,
+    std::function<std::size_t(const MemoKey &key)>
+  >;
 
-// A helper function for constructing a memoization key
-MemoKey memo_key(
-  MemoType type,
-  std::vector<Poi::Token>::const_iterator start,
-  std::shared_ptr<const Poi::Term> application_prior = nullptr
-) {
-  return std::make_tuple(type, start, application_prior);
-}
-
-// Memoize and return a ParseResult representing a success
-template <typename T> ParseResult<T> memo_success(
-  MemoMap &memo,
-  const MemoKey &key,
-  std::shared_ptr<const T> node,
-  std::vector<Poi::Token>::const_iterator next
-) {
-  auto parse_result = ParseResult<T>(node, next);
-  memo.insert({key, parse_result.template upcast<Poi::Node>()});
-  return parse_result;
-}
-
-// Memoize and return a ParseResult representing a failure
-template <typename T> ParseResult<T> memo_error(
-  MemoMap &memo,
-  const MemoKey &key,
-  std::shared_ptr<const ParseError> error
-) {
-  auto parse_result = ParseResult<T>(error);
-  memo.insert({key, parse_result.template upcast<Poi::Node>()});
-  return parse_result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-// Parsing                                                                   //
-///////////////////////////////////////////////////////////////////////////////
-
-// Forward declarations necessary for mutual recursion
-
-ParseResult<Poi::Pattern> parse_pattern(
-  MemoMap &memo,
-  const Poi::StringPool &pool,
-  const Poi::TokenStream &token_stream,
-  const std::unordered_set<std::size_t> &environment,
-  std::vector<Poi::Token>::const_iterator iter
-);
-
-ParseResult<Poi::VariablePattern> parse_variable_pattern(
-  MemoMap &memo,
-  const Poi::StringPool &pool,
-  const Poi::TokenStream &token_stream,
-  const std::unordered_set<std::size_t> &environment,
-  std::vector<Poi::Token>::const_iterator iter
-);
-
-ParseResult<Poi::ConstructorPattern> parse_constructor_pattern(
-  MemoMap &memo,
-  const Poi::StringPool &pool,
-  const Poi::TokenStream &token_stream,
-  const std::unordered_set<std::size_t> &environment,
-  std::vector<Poi::Token>::const_iterator iter
-);
-
-ParseResult<Poi::Term> parse_term(
-  MemoMap &memo,
-  const Poi::StringPool &pool,
-  const Poi::TokenStream &token_stream,
-  const std::unordered_set<std::size_t> &environment,
-  std::vector<Poi::Token>::const_iterator iter
-);
-
-ParseResult<Poi::Variable> parse_variable(
-  MemoMap &memo,
-  const Poi::StringPool &pool,
-  const Poi::TokenStream &token_stream,
-  const std::unordered_set<std::size_t> &environment,
-  std::vector<Poi::Token>::const_iterator iter
-);
-
-ParseResult<Poi::Function> parse_function(
-  MemoMap &memo,
-  const Poi::StringPool &pool,
-  const Poi::TokenStream &token_stream,
-  const std::unordered_set<std::size_t> &environment,
-  std::vector<Poi::Token>::const_iterator iter
-);
-
-ParseResult<Poi::Application> parse_application(
-  MemoMap &memo,
-  const Poi::StringPool &pool,
-  const Poi::TokenStream &token_stream,
-  const std::unordered_set<std::size_t> &environment,
-  std::vector<Poi::Token>::const_iterator iter,
-  std::shared_ptr<const Poi::Term> application_prior
-);
-
-ParseResult<Poi::Binding> parse_binding(
-  MemoMap &memo,
-  const Poi::StringPool &pool,
-  const Poi::TokenStream &token_stream,
-  const std::unordered_set<std::size_t> &environment,
-  std::vector<Poi::Token>::const_iterator iter
-);
-
-ParseResult<Poi::DataType> parse_data_type(
-  MemoMap &memo,
-  const Poi::StringPool &pool,
-  const Poi::TokenStream &token_stream,
-  const std::unordered_set<std::size_t> &environment,
-  std::vector<Poi::Token>::const_iterator iter
-);
-
-ParseResult<Poi::Member> parse_member(
-  MemoMap &memo,
-  const Poi::StringPool &pool,
-  const Poi::TokenStream &token_stream,
-  const std::unordered_set<std::size_t> &environment,
-  std::vector<Poi::Token>::const_iterator iter
-);
-
-ParseResult<Poi::Match> parse_match(
-  MemoMap &memo,
-  const Poi::StringPool &pool,
-  const Poi::TokenStream &token_stream,
-  const std::unordered_set<std::size_t> &environment,
-  std::vector<Poi::Token>::const_iterator iter
-);
-
-ParseResult<Poi::Term> parse_group(
-  MemoMap &memo,
-  const Poi::StringPool &pool,
-  const Poi::TokenStream &token_stream,
-  const std::unordered_set<std::size_t> &environment,
-  std::vector<Poi::Token>::const_iterator iter
-);
-
-// The definitions of the parsing functions
-
-ParseResult<Poi::Pattern> parse_pattern(
-  MemoMap &memo,
-  const Poi::StringPool &pool,
-  const Poi::TokenStream &token_stream,
-  const std::unordered_set<std::size_t> &environment,
-  std::vector<Poi::Token>::const_iterator iter
-) {
-  // Check if we can reuse a memoized result.
-  auto key = memo_key(MemoType::PATTERN, iter);
-  auto memo_result = memo.find(key);
-  if (memo_result != memo.end()) {
-    return memo_result->second.downcast<Poi::Pattern>();
+  // A helper function for constructing a memoization key
+  MemoKey memo_key(
+    MemoType type,
+    std::vector<Token>::const_iterator start,
+    std::shared_ptr<const Term> application_prior = nullptr
+  ) {
+    return std::make_tuple(type, start, application_prior);
   }
 
-  // Make sure we have some tokens to parse.
-  if (iter == token_stream.tokens->end()) {
-    return memo_error<Poi::Pattern>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        "No pattern to parse.",
-        pool.find(token_stream.source_name),
-        pool.find(token_stream.source),
-        ErrorConfidence::LOW
-      )
-    );
+  // Memoize and return a ParseResult representing a success
+  template <typename T> ParseResult<T> memo_success(
+    MemoMap &memo,
+    const MemoKey &key,
+    std::shared_ptr<const T> node,
+    std::vector<Token>::const_iterator next
+  ) {
+    auto parse_result = ParseResult<T>(node, next);
+    memo.insert({key, parse_result.template upcast<Node>()});
+    return parse_result;
   }
 
-  // A pattern is one of the following constructs.
-  auto pattern = ParseResult<Poi::Pattern>(
-    std::make_shared<ParseError>(
-      "Unexpected token.",
-      pool.find(iter->source_name),
-      pool.find(iter->source),
-      iter->start_pos,
-      iter->end_pos,
-      ErrorConfidence::LOW
-    )
-  ).choose(
-    parse_variable_pattern(
-      memo, pool, token_stream, environment, iter
-    ).upcast<Poi::Pattern>()
-  ).choose(
-    parse_constructor_pattern(
-      memo, pool, token_stream, environment, iter
-    ).upcast<Poi::Pattern>()
+  // Memoize and return a ParseResult representing a failure
+  template <typename T> ParseResult<T> memo_error(
+    MemoMap &memo,
+    const MemoKey &key,
+    std::shared_ptr<const ParseError> error
+  ) {
+    auto parse_result = ParseResult<T>(error);
+    memo.insert({key, parse_result.template upcast<Node>()});
+    return parse_result;
+  }
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Parsing                                                                 //
+  /////////////////////////////////////////////////////////////////////////////
+
+  // Forward declarations necessary for mutual recursion
+
+  ParseResult<Pattern> parse_pattern(
+    MemoMap &memo,
+    const StringPool &pool,
+    const TokenStream &token_stream,
+    const std::unordered_set<std::size_t> &environment,
+    std::vector<Token>::const_iterator iter
   );
-  if (pattern.error) {
-    return memo_error<Poi::Pattern>(memo, key, pattern.error);
-  }
 
-  // Memoize and return the result.
-  return memo_success<Poi::Pattern>(memo, key, pattern.node, pattern.next);
-}
-
-ParseResult<Poi::VariablePattern> parse_variable_pattern(
-  MemoMap &memo,
-  const Poi::StringPool &pool,
-  const Poi::TokenStream &token_stream,
-  const std::unordered_set<std::size_t> &environment,
-  std::vector<Poi::Token>::const_iterator iter
-) {
-  // Check if we can reuse a memoized result.
-  auto key = memo_key(MemoType::VARIABLE_PATTERN, iter);
-  auto memo_result = memo.find(key);
-  if (memo_result != memo.end()) {
-    return memo_result->second.downcast<Poi::VariablePattern>();
-  }
-
-  // Make sure we have some tokens to parse.
-  if (iter == token_stream.tokens->end()) {
-    return memo_error<Poi::VariablePattern>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        "No variable pattern to parse.",
-        pool.find(token_stream.source_name),
-        pool.find(token_stream.source),
-        ErrorConfidence::LOW
-      )
-    );
-  }
-
-  // Check whether the current token is an identifier.
-  if (iter->type != Poi::TokenType::IDENTIFIER) {
-    return memo_error<Poi::VariablePattern>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        "A variable pattern must be an identifier.",
-        pool.find(iter->source_name),
-        pool.find(iter->source),
-        iter->start_pos,
-        iter->end_pos,
-        ErrorConfidence::LOW
-      )
-    );
-  }
-
-  // Construct the VariablePattern.
-  auto variables = std::make_shared<const std::unordered_set<std::size_t>>();
-  std::const_pointer_cast<
-    std::unordered_set<std::size_t>
-  >(variables)->insert(iter->literal);
-  auto variable_pattern = std::make_shared<Poi::VariablePattern>(
-    iter->source_name,
-    iter->source,
-    iter->start_pos,
-    iter->end_pos,
-    iter->literal,
-    variables
+  ParseResult<VariablePattern> parse_variable_pattern(
+    MemoMap &memo,
+    const StringPool &pool,
+    const TokenStream &token_stream,
+    const std::unordered_set<std::size_t> &environment,
+    std::vector<Token>::const_iterator iter
   );
-  ++iter;
 
-  // Memoize and return the result.
-  return memo_success<Poi::VariablePattern>(memo, key, variable_pattern, iter);
-}
+  ParseResult<ConstructorPattern> parse_constructor_pattern(
+    MemoMap &memo,
+    const StringPool &pool,
+    const TokenStream &token_stream,
+    const std::unordered_set<std::size_t> &environment,
+    std::vector<Token>::const_iterator iter
+  );
 
-ParseResult<Poi::ConstructorPattern> parse_constructor_pattern(
-  MemoMap &memo,
-  const Poi::StringPool &pool,
-  const Poi::TokenStream &token_stream,
-  const std::unordered_set<std::size_t> &environment,
-  std::vector<Poi::Token>::const_iterator iter
-) {
-  // Check if we can reuse a memoized result.
-  auto key = memo_key(MemoType::CONSTRUCTOR_PATTERN, iter);
-  auto memo_result = memo.find(key);
-  if (memo_result != memo.end()) {
-    return memo_result->second.downcast<Poi::ConstructorPattern>();
-  }
+  ParseResult<Term> parse_term(
+    MemoMap &memo,
+    const StringPool &pool,
+    const TokenStream &token_stream,
+    const std::unordered_set<std::size_t> &environment,
+    std::vector<Token>::const_iterator iter
+  );
 
-  // Mark the beginning of the ConstructorPattern.
-  auto start = iter;
+  ParseResult<Variable> parse_variable(
+    MemoMap &memo,
+    const StringPool &pool,
+    const TokenStream &token_stream,
+    const std::unordered_set<std::size_t> &environment,
+    std::vector<Token>::const_iterator iter
+  );
 
-  // Make sure we have some tokens to parse.
-  if (iter == token_stream.tokens->end()) {
-    return memo_error<Poi::ConstructorPattern>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        "No constructor pattern to parse.",
-        pool.find(token_stream.source_name),
-        pool.find(token_stream.source),
-        ErrorConfidence::LOW
-      )
-    );
-  }
+  ParseResult<Function> parse_function(
+    MemoMap &memo,
+    const StringPool &pool,
+    const TokenStream &token_stream,
+    const std::unordered_set<std::size_t> &environment,
+    std::vector<Token>::const_iterator iter
+  );
 
-  // Parse the LEFT_CURLY.
-  if (iter->type != Poi::TokenType::LEFT_CURLY) {
-    return memo_error<Poi::ConstructorPattern>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        "Expected '{' to introduce this constructor pattern.",
-        pool.find(start->source_name),
-        pool.find(start->source),
-        start->start_pos,
-        iter->end_pos,
-        ErrorConfidence::LOW
-      )
-    );
-  }
-  ++iter;
+  ParseResult<Application> parse_application(
+    MemoMap &memo,
+    const StringPool &pool,
+    const TokenStream &token_stream,
+    const std::unordered_set<std::size_t> &environment,
+    std::vector<Token>::const_iterator iter,
+    std::shared_ptr<const Term> application_prior
+  );
 
-  // Parse the IDENTIFIER.
-  if (iter->type != Poi::TokenType::IDENTIFIER) {
-    return memo_error<Poi::ConstructorPattern>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        "A constructor pattern must begin with the name of a constructor.",
-        pool.find(iter->source_name),
-        pool.find(iter->source),
-        iter->start_pos,
-        iter->end_pos,
-        ErrorConfidence::MED
-      )
-    );
-  }
-  auto constructor_name = iter->literal;
-  ++iter;
+  ParseResult<Binding> parse_binding(
+    MemoMap &memo,
+    const StringPool &pool,
+    const TokenStream &token_stream,
+    const std::unordered_set<std::size_t> &environment,
+    std::vector<Token>::const_iterator iter
+  );
 
-  // Parse the parameters. Note that the lexical analyzer guarantees
-  // curly braces are matched.
-  auto parameters = std::make_shared<
-    std::vector<std::shared_ptr<const Poi::Pattern>>
-  >();
-  auto variables = std::make_shared<const std::unordered_set<std::size_t>>();
-  while (iter->type != Poi::TokenType::RIGHT_CURLY) {
-    auto parameter = ParseResult<Poi::Pattern>(
+  ParseResult<DataType> parse_data_type(
+    MemoMap &memo,
+    const StringPool &pool,
+    const TokenStream &token_stream,
+    const std::unordered_set<std::size_t> &environment,
+    std::vector<Token>::const_iterator iter
+  );
+
+  ParseResult<Member> parse_member(
+    MemoMap &memo,
+    const StringPool &pool,
+    const TokenStream &token_stream,
+    const std::unordered_set<std::size_t> &environment,
+    std::vector<Token>::const_iterator iter
+  );
+
+  ParseResult<Match> parse_match(
+    MemoMap &memo,
+    const StringPool &pool,
+    const TokenStream &token_stream,
+    const std::unordered_set<std::size_t> &environment,
+    std::vector<Token>::const_iterator iter
+  );
+
+  ParseResult<Term> parse_group(
+    MemoMap &memo,
+    const StringPool &pool,
+    const TokenStream &token_stream,
+    const std::unordered_set<std::size_t> &environment,
+    std::vector<Token>::const_iterator iter
+  );
+
+  // The definitions of the parsing functions
+
+  ParseResult<Pattern> parse_pattern(
+    MemoMap &memo,
+    const StringPool &pool,
+    const TokenStream &token_stream,
+    const std::unordered_set<std::size_t> &environment,
+    std::vector<Token>::const_iterator iter
+  ) {
+    // Check if we can reuse a memoized result.
+    auto key = memo_key(MemoType::PATTERN, iter);
+    auto memo_result = memo.find(key);
+    if (memo_result != memo.end()) {
+      return memo_result->second.downcast<Pattern>();
+    }
+
+    // Make sure we have some tokens to parse.
+    if (iter == token_stream.tokens->end()) {
+      return memo_error<Pattern>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          "No pattern to parse.",
+          pool.find(token_stream.source_name),
+          pool.find(token_stream.source),
+          ErrorConfidence::LOW
+        )
+      );
+    }
+
+    // A pattern is one of the following constructs.
+    auto pattern = ParseResult<Pattern>(
       std::make_shared<ParseError>(
         "Unexpected token.",
         pool.find(iter->source_name),
@@ -575,438 +414,267 @@ ParseResult<Poi::ConstructorPattern> parse_constructor_pattern(
         ErrorConfidence::LOW
       )
     ).choose(
-      parse_pattern(
-        memo,
-        pool,
-        token_stream,
-        environment,
-        iter
-      )
+      parse_variable_pattern(
+        memo, pool, token_stream, environment, iter
+      ).upcast<Pattern>()
+    ).choose(
+      parse_constructor_pattern(
+        memo, pool, token_stream, environment, iter
+      ).upcast<Pattern>()
     );
-    if (parameter.error) {
-      return memo_error<Poi::ConstructorPattern>(
+    if (pattern.error) {
+      return memo_error<Pattern>(memo, key, pattern.error);
+    }
+
+    // Memoize and return the result.
+    return memo_success<Pattern>(memo, key, pattern.node, pattern.next);
+  }
+
+  ParseResult<VariablePattern> parse_variable_pattern(
+    MemoMap &memo,
+    const StringPool &pool,
+    const TokenStream &token_stream,
+    const std::unordered_set<std::size_t> &environment,
+    std::vector<Token>::const_iterator iter
+  ) {
+    // Check if we can reuse a memoized result.
+    auto key = memo_key(MemoType::VARIABLE_PATTERN, iter);
+    auto memo_result = memo.find(key);
+    if (memo_result != memo.end()) {
+      return memo_result->second.downcast<VariablePattern>();
+    }
+
+    // Make sure we have some tokens to parse.
+    if (iter == token_stream.tokens->end()) {
+      return memo_error<VariablePattern>(
         memo,
         key,
         std::make_shared<ParseError>(
-          parameter.error->what(),
+          "No variable pattern to parse.",
+          pool.find(token_stream.source_name),
+          pool.find(token_stream.source),
+          ErrorConfidence::LOW
+        )
+      );
+    }
+
+    // Check whether the current token is an identifier.
+    if (iter->type != TokenType::IDENTIFIER) {
+      return memo_error<VariablePattern>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          "A variable pattern must be an identifier.",
+          pool.find(iter->source_name),
+          pool.find(iter->source),
+          iter->start_pos,
+          iter->end_pos,
+          ErrorConfidence::LOW
+        )
+      );
+    }
+
+    // Construct the VariablePattern.
+    auto variables = std::make_shared<const std::unordered_set<std::size_t>>();
+    std::const_pointer_cast<
+      std::unordered_set<std::size_t>
+    >(variables)->insert(iter->literal);
+    auto variable_pattern = std::make_shared<VariablePattern>(
+      iter->source_name,
+      iter->source,
+      iter->start_pos,
+      iter->end_pos,
+      iter->literal,
+      variables
+    );
+    ++iter;
+
+    // Memoize and return the result.
+    return memo_success<VariablePattern>(
+      memo,
+      key,
+      variable_pattern,
+      iter
+    );
+  }
+
+  ParseResult<ConstructorPattern> parse_constructor_pattern(
+    MemoMap &memo,
+    const StringPool &pool,
+    const TokenStream &token_stream,
+    const std::unordered_set<std::size_t> &environment,
+    std::vector<Token>::const_iterator iter
+  ) {
+    // Check if we can reuse a memoized result.
+    auto key = memo_key(MemoType::CONSTRUCTOR_PATTERN, iter);
+    auto memo_result = memo.find(key);
+    if (memo_result != memo.end()) {
+      return memo_result->second.downcast<ConstructorPattern>();
+    }
+
+    // Mark the beginning of the ConstructorPattern.
+    auto start = iter;
+
+    // Make sure we have some tokens to parse.
+    if (iter == token_stream.tokens->end()) {
+      return memo_error<ConstructorPattern>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          "No constructor pattern to parse.",
+          pool.find(token_stream.source_name),
+          pool.find(token_stream.source),
+          ErrorConfidence::LOW
+        )
+      );
+    }
+
+    // Parse the LEFT_CURLY.
+    if (iter->type != TokenType::LEFT_CURLY) {
+      return memo_error<ConstructorPattern>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          "Expected '{' to introduce this constructor pattern.",
+          pool.find(start->source_name),
+          pool.find(start->source),
+          start->start_pos,
+          iter->end_pos,
+          ErrorConfidence::LOW
+        )
+      );
+    }
+    ++iter;
+
+    // Parse the IDENTIFIER.
+    if (iter->type != TokenType::IDENTIFIER) {
+      return memo_error<ConstructorPattern>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          "A constructor pattern must begin with the name of a constructor.",
+          pool.find(iter->source_name),
+          pool.find(iter->source),
+          iter->start_pos,
+          iter->end_pos,
           ErrorConfidence::MED
         )
       );
     }
-    iter = parameter.next;
-    parameters->push_back(parameter.node);
-    for (auto &variable : *(parameter.node->variables)) {
-      if (variables->find(variable) != variables->end()) {
-        return memo_error<Poi::ConstructorPattern>(
+    auto constructor_name = iter->literal;
+    ++iter;
+
+    // Parse the parameters. Note that the lexical analyzer guarantees
+    // curly braces are matched.
+    auto parameters = std::make_shared<
+      std::vector<std::shared_ptr<const Pattern>>
+    >();
+    auto variables = std::make_shared<const std::unordered_set<std::size_t>>();
+    while (iter->type != TokenType::RIGHT_CURLY) {
+      auto parameter = ParseResult<Pattern>(
+        std::make_shared<ParseError>(
+          "Unexpected token.",
+          pool.find(iter->source_name),
+          pool.find(iter->source),
+          iter->start_pos,
+          iter->end_pos,
+          ErrorConfidence::LOW
+        )
+      ).choose(
+        parse_pattern(
+          memo,
+          pool,
+          token_stream,
+          environment,
+          iter
+        )
+      );
+      if (parameter.error) {
+        return memo_error<ConstructorPattern>(
           memo,
           key,
           std::make_shared<ParseError>(
-            "Duplicate variable '" + pool.find(variable) + "' in pattern.",
-            pool.find(parameter.node->source_name),
-            pool.find(parameter.node->source),
-            parameter.node->start_pos,
-            parameter.node->end_pos,
+            parameter.error->what(),
             ErrorConfidence::MED
           )
         );
       }
-      std::const_pointer_cast<
-        std::unordered_set<std::size_t>
-      >(variables)->insert(variable);
+      iter = parameter.next;
+      parameters->push_back(parameter.node);
+      for (auto &variable : *(parameter.node->variables)) {
+        if (variables->find(variable) != variables->end()) {
+          return memo_error<ConstructorPattern>(
+            memo,
+            key,
+            std::make_shared<ParseError>(
+              "Duplicate variable '" + pool.find(variable) + "' in pattern.",
+              pool.find(parameter.node->source_name),
+              pool.find(parameter.node->source),
+              parameter.node->start_pos,
+              parameter.node->end_pos,
+              ErrorConfidence::MED
+            )
+          );
+        }
+        std::const_pointer_cast<
+          std::unordered_set<std::size_t>
+        >(variables)->insert(variable);
+      }
     }
-  }
 
-  // Skip the closing RIGHT_CURLY.
-  ++iter;
+    // Skip the closing RIGHT_CURLY.
+    ++iter;
 
-  // Construct the ConstructorPattern.
-  auto constructor_pattern = std::make_shared<Poi::ConstructorPattern>(
-    start->source_name,
-    start->source,
-    start->start_pos,
-    (iter - 1)->end_pos,
-    constructor_name,
-    parameters,
-    variables
-  );
-
-  // Memoize and return the result.
-  return memo_success<Poi::ConstructorPattern>(
-    memo,
-    key,
-    constructor_pattern,
-    iter
-  );
-}
-
-ParseResult<Poi::Term> parse_term(
-  MemoMap &memo,
-  const Poi::StringPool &pool,
-  const Poi::TokenStream &token_stream,
-  const std::unordered_set<std::size_t> &environment,
-  std::vector<Poi::Token>::const_iterator iter
-) {
-  // Check if we can reuse a memoized result.
-  auto key = memo_key(MemoType::TERM, iter);
-  auto memo_result = memo.find(key);
-  if (memo_result != memo.end()) {
-    return memo_result->second.downcast<Poi::Term>();
-  }
-
-  // Make sure we have some tokens to parse.
-  if (iter == token_stream.tokens->end()) {
-    return memo_error<Poi::Term>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        "No term to parse.",
-        pool.find(token_stream.source_name),
-        pool.find(token_stream.source),
-        ErrorConfidence::LOW
-      )
-    );
-  }
-
-  // A term is one of the following constructs.
-  auto term = ParseResult<Poi::Term>(
-    std::make_shared<ParseError>(
-      "Unexpected token.",
-      pool.find(iter->source_name),
-      pool.find(iter->source),
-      iter->start_pos,
-      iter->end_pos,
-      ErrorConfidence::LOW
-    )
-  ).choose(
-    parse_variable(
-      memo, pool, token_stream, environment, iter
-    ).upcast<Poi::Term>()
-  ).choose(
-    parse_function(
-      memo, pool, token_stream, environment, iter
-    ).upcast<Poi::Term>()
-  ).choose(
-    parse_application(
-      memo, pool, token_stream, environment, iter, nullptr
-    ).upcast<Poi::Term>()
-  ).choose(
-    parse_binding(
-      memo, pool, token_stream, environment, iter
-    ).upcast<Poi::Term>()
-  ).choose(
-    parse_data_type(
-      memo, pool, token_stream, environment, iter
-    ).upcast<Poi::Term>()
-  ).choose(
-    parse_member(
-      memo, pool, token_stream, environment, iter
-    ).upcast<Poi::Term>()
-  ).choose(
-    parse_match(
-      memo, pool, token_stream, environment, iter
-    ).upcast<Poi::Term>()
-  ).choose(
-    parse_group(
-      memo, pool, token_stream, environment, iter
-    ).upcast<Poi::Term>()
-  );
-  if (term.error) {
-    return memo_error<Poi::Term>(memo, key, term.error);
-  }
-
-  // Memoize and return the result.
-  return memo_success<Poi::Term>(memo, key, term.node, term.next);
-}
-
-ParseResult<Poi::Variable> parse_variable(
-  MemoMap &memo,
-  const Poi::StringPool &pool,
-  const Poi::TokenStream &token_stream,
-  const std::unordered_set<std::size_t> &environment,
-  std::vector<Poi::Token>::const_iterator iter
-) {
-  // Check if we can reuse a memoized result.
-  auto key = memo_key(MemoType::VARIABLE, iter);
-  auto memo_result = memo.find(key);
-  if (memo_result != memo.end()) {
-    return memo_result->second.downcast<Poi::Variable>();
-  }
-
-  // Make sure we have some tokens to parse.
-  if (iter == token_stream.tokens->end()) {
-    return memo_error<Poi::Variable>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        "No variable to parse.",
-        pool.find(token_stream.source_name),
-        pool.find(token_stream.source),
-        ErrorConfidence::LOW
-      )
-    );
-  }
-
-  // Parse the IDENTIFIER.
-  if (iter->type != Poi::TokenType::IDENTIFIER) {
-    return memo_error<Poi::Variable>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        "A variable must be an identifier.",
-        pool.find(iter->source_name),
-        pool.find(iter->source),
-        iter->start_pos,
-        iter->end_pos,
-        ErrorConfidence::LOW
-      )
-    );
-  }
-  auto variable_name = iter->literal;
-
-  // Look up the variable in the environment.
-  if (environment.find(variable_name) == environment.end()) {
-    ErrorConfidence confidence = ErrorConfidence::LOW;
-    if (
-      iter + 1 == token_stream.tokens->end() || (
-        (iter + 1)->type != Poi::TokenType::ARROW &&
-        (iter + 1)->type != Poi::TokenType::EQUALS
-      )
-    ) {
-      confidence = ErrorConfidence::HIGH;
-    }
-    return memo_error<Poi::Variable>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        "Undefined variable '" + pool.find(variable_name) + "'.",
-        pool.find(iter->source_name),
-        pool.find(iter->source),
-        iter->start_pos,
-        iter->end_pos,
-        confidence
-      )
-    );
-  }
-  ++iter;
-
-  // Construct the Variable.
-  auto free_variables = std::make_shared<std::unordered_set<std::size_t>>();
-  free_variables->insert(variable_name);
-  auto variable = std::make_shared<Poi::Variable>(
-    (iter - 1)->source_name,
-    (iter - 1)->source,
-    (iter - 1)->start_pos,
-    (iter - 1)->end_pos,
-    free_variables,
-    variable_name
-  );
-
-  // Memoize and return the result.
-  return memo_success<Poi::Variable>(memo, key, variable, iter);
-}
-
-ParseResult<Poi::Function> parse_function(
-  MemoMap &memo,
-  const Poi::StringPool &pool,
-  const Poi::TokenStream &token_stream,
-  const std::unordered_set<std::size_t> &environment,
-  std::vector<Poi::Token>::const_iterator iter
-) {
-  // Check if we can reuse a memoized result.
-  auto key = memo_key(MemoType::FUNCTION, iter);
-  auto memo_result = memo.find(key);
-  if (memo_result != memo.end()) {
-    return memo_result->second.downcast<Poi::Function>();
-  }
-
-  // Mark the beginning of the Function.
-  auto start = iter;
-
-  // Make sure we have some tokens to parse.
-  if (iter == token_stream.tokens->end()) {
-    return memo_error<Poi::Function>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        "No function to parse.",
-        pool.find(token_stream.source_name),
-        pool.find(token_stream.source),
-        ErrorConfidence::LOW
-      )
-    );
-  }
-
-  // Parse the Pattern.
-  auto pattern = ParseResult<Poi::Pattern>(
-    std::make_shared<ParseError>(
-      "No pattern found for this binding.",
-      pool.find(start->source_name),
-      pool.find(start->source),
-      start->start_pos,
-      iter->end_pos,
-      ErrorConfidence::LOW
-    )
-  ).choose(parse_pattern(memo, pool, token_stream, environment, iter));
-  if (pattern.error) {
-    return memo_error<Poi::Function>(memo, key, pattern.error);
-  }
-  iter = pattern.next;
-
-  // Parse the ARROW.
-  if (
-    iter == token_stream.tokens->end() ||
-    iter->type != Poi::TokenType::ARROW
-  ) {
-    return memo_error<Poi::Function>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        "Expected '->' in this function.",
-        pool.find(start->source_name),
-        pool.find(start->source),
-        start->start_pos,
-        (iter - 1)->end_pos,
-        ErrorConfidence::LOW
-      )
-    );
-  }
-  ++iter;
-
-  // Add the pattern variables to the environment.
-  auto new_environment = environment;
-  new_environment.insert(
-    pattern.node->variables->begin(),
-    pattern.node->variables->end()
-  );
-
-  // Parse the body.
-  auto body = ParseResult<Poi::Term>(
-    std::make_shared<ParseError>(
-      "No body found for this function.",
-      pool.find(start->source_name),
-      pool.find(start->source),
+    // Construct the ConstructorPattern.
+    auto constructor_pattern = std::make_shared<ConstructorPattern>(
+      start->source_name,
+      start->source,
       start->start_pos,
       (iter - 1)->end_pos,
-      ErrorConfidence::LOW
-    )
-  ).choose(parse_term(memo, pool, token_stream, new_environment, iter));
-  if (body.error) {
-    return memo_error<Poi::Function>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        body.error->what(),
-        ErrorConfidence::HIGH
-      )
+      constructor_name,
+      parameters,
+      variables
     );
-  }
-  iter = body.next;
 
-  // Construct the Function.
-  auto free_variables = std::make_shared<std::unordered_set<std::size_t>>();
-  free_variables->insert(
-    body.node->free_variables->begin(),
-    body.node->free_variables->end()
-  );
-  for (auto &variable : *(pattern.node->variables)) {
-    free_variables->erase(variable);
-  }
-  auto function = std::make_shared<Poi::Function>(
-    start->source_name,
-    start->source,
-    start->start_pos,
-    (iter - 1)->end_pos,
-    free_variables,
-    pattern.node,
-    body.node
-  );
-
-  // Memoize and return the result.
-  return memo_success<Poi::Function>(memo, key, function, iter);
-}
-
-ParseResult<Poi::Application> parse_application(
-  MemoMap &memo,
-  const Poi::StringPool &pool,
-  const Poi::TokenStream &token_stream,
-  const std::unordered_set<std::size_t> &environment,
-  std::vector<Poi::Token>::const_iterator iter,
-  std::shared_ptr<const Poi::Term> application_prior
-) {
-  // Check if we can reuse a memoized result.
-  auto key = memo_key(MemoType::APPLICATION, iter, application_prior);
-  auto memo_result = memo.find(key);
-  if (memo_result != memo.end()) {
-    return memo_result->second.downcast<Poi::Application>();
-  }
-
-  // Make sure we have some tokens to parse.
-  if (iter == token_stream.tokens->end()) {
-    return memo_error<Poi::Application>(
+    // Memoize and return the result.
+    return memo_success<ConstructorPattern>(
       memo,
       key,
-      std::make_shared<ParseError>(
-        "No left subterm to parse.",
-        pool.find(token_stream.source_name),
-        pool.find(token_stream.source),
-        ErrorConfidence::LOW
-      )
+      constructor_pattern,
+      iter
     );
   }
 
-  // Parse the left term.
-  auto left = ParseResult<Poi::Term>(
-    std::make_shared<ParseError>(
-      "Unexpected token.",
-      pool.find(iter->source_name),
-      pool.find(iter->source),
-      iter->start_pos,
-      iter->end_pos,
-      ErrorConfidence::LOW
-    )
-  ).choose(
-    parse_variable(
-      memo, pool, token_stream, environment, iter
-    ).upcast<Poi::Term>()
-  ).choose(
-    parse_data_type(
-      memo, pool, token_stream, environment, iter
-    ).upcast<Poi::Term>()
-  ).choose(
-    parse_member(
-      memo, pool, token_stream, environment, iter
-    ).upcast<Poi::Term>()
-  ).choose(
-    parse_match(
-      memo, pool, token_stream, environment, iter
-    ).upcast<Poi::Term>()
-  ).choose(
-    parse_group(
-      memo, pool, token_stream, environment, iter
-    )
-  );
-  if (left.error) {
-    return memo_error<Poi::Application>(memo, key, left.error);
-  }
-  iter = left.next;
+  ParseResult<Term> parse_term(
+    MemoMap &memo,
+    const StringPool &pool,
+    const TokenStream &token_stream,
+    const std::unordered_set<std::size_t> &environment,
+    std::vector<Token>::const_iterator iter
+  ) {
+    // Check if we can reuse a memoized result.
+    auto key = memo_key(MemoType::TERM, iter);
+    auto memo_result = memo.find(key);
+    if (memo_result != memo.end()) {
+      return memo_result->second.downcast<Term>();
+    }
 
-  // Make sure we have some tokens to parse.
-  if (iter == token_stream.tokens->end()) {
-    return memo_error<Poi::Application>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        "No right subterm to parse.",
-        pool.find(token_stream.source_name),
-        pool.find(token_stream.source),
-        ErrorConfidence::LOW
-      )
-    );
-  }
+    // Make sure we have some tokens to parse.
+    if (iter == token_stream.tokens->end()) {
+      return memo_error<Term>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          "No term to parse.",
+          pool.find(token_stream.source_name),
+          pool.find(token_stream.source),
+          ErrorConfidence::LOW
+        )
+      );
+    }
 
-  // Parse the right term.
-  auto right = std::make_shared<ParseResult<Poi::Term>>(
-    ParseResult<Poi::Term>(
+    // A term is one of the following constructs.
+    auto term = ParseResult<Term>(
       std::make_shared<ParseError>(
         "Unexpected token.",
         pool.find(iter->source_name),
@@ -1018,86 +686,363 @@ ParseResult<Poi::Application> parse_application(
     ).choose(
       parse_variable(
         memo, pool, token_stream, environment, iter
-      ).upcast<Poi::Term>()
+      ).upcast<Term>()
+    ).choose(
+      parse_function(
+        memo, pool, token_stream, environment, iter
+      ).upcast<Term>()
+    ).choose(
+      parse_application(
+        memo, pool, token_stream, environment, iter, nullptr
+      ).upcast<Term>()
+    ).choose(
+      parse_binding(
+        memo, pool, token_stream, environment, iter
+      ).upcast<Term>()
     ).choose(
       parse_data_type(
         memo, pool, token_stream, environment, iter
-      ).upcast<Poi::Term>()
+      ).upcast<Term>()
     ).choose(
       parse_member(
         memo, pool, token_stream, environment, iter
-      ).upcast<Poi::Term>()
+      ).upcast<Term>()
     ).choose(
       parse_match(
         memo, pool, token_stream, environment, iter
-      ).upcast<Poi::Term>()
+      ).upcast<Term>()
+    ).choose(
+      parse_group(
+        memo, pool, token_stream, environment, iter
+      ).upcast<Term>()
+    );
+    if (term.error) {
+      return memo_error<Term>(memo, key, term.error);
+    }
+
+    // Memoize and return the result.
+    return memo_success<Term>(memo, key, term.node, term.next);
+  }
+
+  ParseResult<Variable> parse_variable(
+    MemoMap &memo,
+    const StringPool &pool,
+    const TokenStream &token_stream,
+    const std::unordered_set<std::size_t> &environment,
+    std::vector<Token>::const_iterator iter
+  ) {
+    // Check if we can reuse a memoized result.
+    auto key = memo_key(MemoType::VARIABLE, iter);
+    auto memo_result = memo.find(key);
+    if (memo_result != memo.end()) {
+      return memo_result->second.downcast<Variable>();
+    }
+
+    // Make sure we have some tokens to parse.
+    if (iter == token_stream.tokens->end()) {
+      return memo_error<Variable>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          "No variable to parse.",
+          pool.find(token_stream.source_name),
+          pool.find(token_stream.source),
+          ErrorConfidence::LOW
+        )
+      );
+    }
+
+    // Parse the IDENTIFIER.
+    if (iter->type != TokenType::IDENTIFIER) {
+      return memo_error<Variable>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          "A variable must be an identifier.",
+          pool.find(iter->source_name),
+          pool.find(iter->source),
+          iter->start_pos,
+          iter->end_pos,
+          ErrorConfidence::LOW
+        )
+      );
+    }
+    auto variable_name = iter->literal;
+
+    // Look up the variable in the environment.
+    if (environment.find(variable_name) == environment.end()) {
+      ErrorConfidence confidence = ErrorConfidence::LOW;
+      if (
+        iter + 1 == token_stream.tokens->end() || (
+          (iter + 1)->type != TokenType::ARROW &&
+          (iter + 1)->type != TokenType::EQUALS
+        )
+      ) {
+        confidence = ErrorConfidence::HIGH;
+      }
+      return memo_error<Variable>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          "Undefined variable '" + pool.find(variable_name) + "'.",
+          pool.find(iter->source_name),
+          pool.find(iter->source),
+          iter->start_pos,
+          iter->end_pos,
+          confidence
+        )
+      );
+    }
+    ++iter;
+
+    // Construct the Variable.
+    auto free_variables = std::make_shared<std::unordered_set<std::size_t>>();
+    free_variables->insert(variable_name);
+    auto variable = std::make_shared<Variable>(
+      (iter - 1)->source_name,
+      (iter - 1)->source,
+      (iter - 1)->start_pos,
+      (iter - 1)->end_pos,
+      free_variables,
+      variable_name
+    );
+
+    // Memoize and return the result.
+    return memo_success<Variable>(memo, key, variable, iter);
+  }
+
+  ParseResult<Function> parse_function(
+    MemoMap &memo,
+    const StringPool &pool,
+    const TokenStream &token_stream,
+    const std::unordered_set<std::size_t> &environment,
+    std::vector<Token>::const_iterator iter
+  ) {
+    // Check if we can reuse a memoized result.
+    auto key = memo_key(MemoType::FUNCTION, iter);
+    auto memo_result = memo.find(key);
+    if (memo_result != memo.end()) {
+      return memo_result->second.downcast<Function>();
+    }
+
+    // Mark the beginning of the Function.
+    auto start = iter;
+
+    // Make sure we have some tokens to parse.
+    if (iter == token_stream.tokens->end()) {
+      return memo_error<Function>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          "No function to parse.",
+          pool.find(token_stream.source_name),
+          pool.find(token_stream.source),
+          ErrorConfidence::LOW
+        )
+      );
+    }
+
+    // Parse the Pattern.
+    auto pattern = ParseResult<Pattern>(
+      std::make_shared<ParseError>(
+        "No pattern found for this binding.",
+        pool.find(start->source_name),
+        pool.find(start->source),
+        start->start_pos,
+        iter->end_pos,
+        ErrorConfidence::LOW
+      )
+    ).choose(parse_pattern(memo, pool, token_stream, environment, iter));
+    if (pattern.error) {
+      return memo_error<Function>(memo, key, pattern.error);
+    }
+    iter = pattern.next;
+
+    // Parse the ARROW.
+    if (
+      iter == token_stream.tokens->end() ||
+      iter->type != TokenType::ARROW
+    ) {
+      return memo_error<Function>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          "Expected '->' in this function.",
+          pool.find(start->source_name),
+          pool.find(start->source),
+          start->start_pos,
+          (iter - 1)->end_pos,
+          ErrorConfidence::LOW
+        )
+      );
+    }
+    ++iter;
+
+    // Add the pattern variables to the environment.
+    auto new_environment = environment;
+    new_environment.insert(
+      pattern.node->variables->begin(),
+      pattern.node->variables->end()
+    );
+
+    // Parse the body.
+    auto body = ParseResult<Term>(
+      std::make_shared<ParseError>(
+        "No body found for this function.",
+        pool.find(start->source_name),
+        pool.find(start->source),
+        start->start_pos,
+        (iter - 1)->end_pos,
+        ErrorConfidence::LOW
+      )
+    ).choose(parse_term(memo, pool, token_stream, new_environment, iter));
+    if (body.error) {
+      return memo_error<Function>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          body.error->what(),
+          ErrorConfidence::HIGH
+        )
+      );
+    }
+    iter = body.next;
+
+    // Construct the Function.
+    auto free_variables = std::make_shared<std::unordered_set<std::size_t>>();
+    free_variables->insert(
+      body.node->free_variables->begin(),
+      body.node->free_variables->end()
+    );
+    for (auto &variable : *(pattern.node->variables)) {
+      free_variables->erase(variable);
+    }
+    auto function = std::make_shared<Function>(
+      start->source_name,
+      start->source,
+      start->start_pos,
+      (iter - 1)->end_pos,
+      free_variables,
+      pattern.node,
+      body.node
+    );
+
+    // Memoize and return the result.
+    return memo_success<Function>(memo, key, function, iter);
+  }
+
+  ParseResult<Application> parse_application(
+    MemoMap &memo,
+    const StringPool &pool,
+    const TokenStream &token_stream,
+    const std::unordered_set<std::size_t> &environment,
+    std::vector<Token>::const_iterator iter,
+    std::shared_ptr<const Term> application_prior
+  ) {
+    // Check if we can reuse a memoized result.
+    auto key = memo_key(MemoType::APPLICATION, iter, application_prior);
+    auto memo_result = memo.find(key);
+    if (memo_result != memo.end()) {
+      return memo_result->second.downcast<Application>();
+    }
+
+    // Make sure we have some tokens to parse.
+    if (iter == token_stream.tokens->end()) {
+      return memo_error<Application>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          "No left subterm to parse.",
+          pool.find(token_stream.source_name),
+          pool.find(token_stream.source),
+          ErrorConfidence::LOW
+        )
+      );
+    }
+
+    // Parse the left term.
+    auto left = ParseResult<Term>(
+      std::make_shared<ParseError>(
+        "Unexpected token.",
+        pool.find(iter->source_name),
+        pool.find(iter->source),
+        iter->start_pos,
+        iter->end_pos,
+        ErrorConfidence::LOW
+      )
+    ).choose(
+      parse_variable(
+        memo, pool, token_stream, environment, iter
+      ).upcast<Term>()
+    ).choose(
+      parse_data_type(
+        memo, pool, token_stream, environment, iter
+      ).upcast<Term>()
+    ).choose(
+      parse_member(
+        memo, pool, token_stream, environment, iter
+      ).upcast<Term>()
+    ).choose(
+      parse_match(
+        memo, pool, token_stream, environment, iter
+      ).upcast<Term>()
     ).choose(
       parse_group(
         memo, pool, token_stream, environment, iter
       )
-    )
-  );
-  if (application_prior) {
-    auto prior_of_left_free_variables = std::make_shared<
-      std::unordered_set<std::size_t>
-    >();
-    prior_of_left_free_variables->insert(
-      application_prior->free_variables->begin(),
-      application_prior->free_variables->end()
     );
-    prior_of_left_free_variables->insert(
-      left.node->free_variables->begin(),
-      left.node->free_variables->end()
-    );
-    auto prior_of_left = std::make_shared<Poi::Application>(
-      application_prior->source_name,
-      application_prior->source,
-      application_prior->start_pos,
-      left.node->end_pos,
-      prior_of_left_free_variables,
-      application_prior,
-      left.node
-    );
-    right = std::make_shared<ParseResult<Poi::Term>>(
-      right->choose(
-        parse_application(
-          memo,
-          pool,
-          token_stream,
-          environment,
-          iter,
-          prior_of_left
-        ).upcast<Poi::Term>()
-      )
-    );
-  } else {
-    right = std::make_shared<ParseResult<Poi::Term>>(
-      right->choose(
-        parse_application(
-          memo,
-          pool,
-          token_stream,
-          environment,
-          iter,
-          left.node
-        ).upcast<Poi::Term>()
-      )
-    );
-  }
-  if (right->error) {
-    return memo_error<Poi::Application>(memo, key, right->error);
-  }
-  bool right_includes_left = right->node->start_pos < iter->start_pos;
-  iter = right->next;
+    if (left.error) {
+      return memo_error<Application>(memo, key, left.error);
+    }
+    iter = left.next;
 
-  // Construct the Application. Special care is taken to construct the tree
-  // with left-associativity, even though we are parsing with right-recursion.
-  std::shared_ptr<const Poi::Application> application;
-  if (right_includes_left) {
-    application = std::dynamic_pointer_cast<
-      const Poi::Application
-    >(right->node);
-  } else {
+    // Make sure we have some tokens to parse.
+    if (iter == token_stream.tokens->end()) {
+      return memo_error<Application>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          "No right subterm to parse.",
+          pool.find(token_stream.source_name),
+          pool.find(token_stream.source),
+          ErrorConfidence::LOW
+        )
+      );
+    }
+
+    // Parse the right term.
+    auto right = std::make_shared<ParseResult<Term>>(
+      ParseResult<Term>(
+        std::make_shared<ParseError>(
+          "Unexpected token.",
+          pool.find(iter->source_name),
+          pool.find(iter->source),
+          iter->start_pos,
+          iter->end_pos,
+          ErrorConfidence::LOW
+        )
+      ).choose(
+        parse_variable(
+          memo, pool, token_stream, environment, iter
+        ).upcast<Term>()
+      ).choose(
+        parse_data_type(
+          memo, pool, token_stream, environment, iter
+        ).upcast<Term>()
+      ).choose(
+        parse_member(
+          memo, pool, token_stream, environment, iter
+        ).upcast<Term>()
+      ).choose(
+        parse_match(
+          memo, pool, token_stream, environment, iter
+        ).upcast<Term>()
+      ).choose(
+        parse_group(
+          memo, pool, token_stream, environment, iter
+        )
+      )
+    );
     if (application_prior) {
       auto prior_of_left_free_variables = std::make_shared<
         std::unordered_set<std::size_t>
@@ -1110,7 +1055,7 @@ ParseResult<Poi::Application> parse_application(
         left.node->free_variables->begin(),
         left.node->free_variables->end()
       );
-      auto prior_of_left = std::make_shared<Poi::Application>(
+      auto prior_of_left = std::make_shared<Application>(
         application_prior->source_name,
         application_prior->source,
         application_prior->start_pos,
@@ -1119,328 +1064,366 @@ ParseResult<Poi::Application> parse_application(
         application_prior,
         left.node
       );
-
-      auto free_variables = std::make_shared<
-        std::unordered_set<std::size_t>
-      >();
-      free_variables->insert(
-        prior_of_left->free_variables->begin(),
-        prior_of_left->free_variables->end()
-      );
-      free_variables->insert(
-        right->node->free_variables->begin(),
-        right->node->free_variables->end()
-      );
-
-      application = std::make_shared<Poi::Application>(
-        prior_of_left->source_name,
-        prior_of_left->source,
-        prior_of_left->start_pos,
-        right->node->end_pos,
-        free_variables,
-        prior_of_left,
-        right->node
+      right = std::make_shared<ParseResult<Term>>(
+        right->choose(
+          parse_application(
+            memo,
+            pool,
+            token_stream,
+            environment,
+            iter,
+            prior_of_left
+          ).upcast<Term>()
+        )
       );
     } else {
-      auto free_variables = std::make_shared<
-        std::unordered_set<std::size_t>
-      >();
-      free_variables->insert(
-        left.node->free_variables->begin(),
-        left.node->free_variables->end()
-      );
-      free_variables->insert(
-        right->node->free_variables->begin(),
-        right->node->free_variables->end()
-      );
-      application = std::make_shared<Poi::Application>(
-        left.node->source_name,
-        left.node->source,
-        left.node->start_pos,
-        right->node->end_pos,
-        free_variables,
-        left.node,
-        right->node
+      right = std::make_shared<ParseResult<Term>>(
+        right->choose(
+          parse_application(
+            memo,
+            pool,
+            token_stream,
+            environment,
+            iter,
+            left.node
+          ).upcast<Term>()
+        )
       );
     }
+    if (right->error) {
+      return memo_error<Application>(memo, key, right->error);
+    }
+    bool right_includes_left = right->node->start_pos < iter->start_pos;
+    iter = right->next;
+
+    // Construct the Application. Special care is taken to construct the tree
+    // with left-associativity, even though we are parsing with right-
+    // recursion.
+    std::shared_ptr<const Application> application;
+    if (right_includes_left) {
+      application = std::dynamic_pointer_cast<
+        const Application
+      >(right->node);
+    } else {
+      if (application_prior) {
+        auto prior_of_left_free_variables = std::make_shared<
+          std::unordered_set<std::size_t>
+        >();
+        prior_of_left_free_variables->insert(
+          application_prior->free_variables->begin(),
+          application_prior->free_variables->end()
+        );
+        prior_of_left_free_variables->insert(
+          left.node->free_variables->begin(),
+          left.node->free_variables->end()
+        );
+        auto prior_of_left = std::make_shared<Application>(
+          application_prior->source_name,
+          application_prior->source,
+          application_prior->start_pos,
+          left.node->end_pos,
+          prior_of_left_free_variables,
+          application_prior,
+          left.node
+        );
+
+        auto free_variables = std::make_shared<
+          std::unordered_set<std::size_t>
+        >();
+        free_variables->insert(
+          prior_of_left->free_variables->begin(),
+          prior_of_left->free_variables->end()
+        );
+        free_variables->insert(
+          right->node->free_variables->begin(),
+          right->node->free_variables->end()
+        );
+
+        application = std::make_shared<Application>(
+          prior_of_left->source_name,
+          prior_of_left->source,
+          prior_of_left->start_pos,
+          right->node->end_pos,
+          free_variables,
+          prior_of_left,
+          right->node
+        );
+      } else {
+        auto free_variables = std::make_shared<
+          std::unordered_set<std::size_t>
+        >();
+        free_variables->insert(
+          left.node->free_variables->begin(),
+          left.node->free_variables->end()
+        );
+        free_variables->insert(
+          right->node->free_variables->begin(),
+          right->node->free_variables->end()
+        );
+        application = std::make_shared<Application>(
+          left.node->source_name,
+          left.node->source,
+          left.node->start_pos,
+          right->node->end_pos,
+          free_variables,
+          left.node,
+          right->node
+        );
+      }
+    }
+
+    // Memoize and return the result.
+    return memo_success<Application>(memo, key, application, iter);
   }
 
-  // Memoize and return the result.
-  return memo_success<Poi::Application>(memo, key, application, iter);
-}
-
-ParseResult<Poi::Binding> parse_binding(
-  MemoMap &memo,
-  const Poi::StringPool &pool,
-  const Poi::TokenStream &token_stream,
-  const std::unordered_set<std::size_t> &environment,
-  std::vector<Poi::Token>::const_iterator iter
-) {
-  // Check if we can reuse a memoized result.
-  auto key = memo_key(MemoType::BINDING, iter);
-  auto memo_result = memo.find(key);
-  if (memo_result != memo.end()) {
-    return memo_result->second.downcast<Poi::Binding>();
-  }
-
-  // Mark the beginning of the Binding.
-  auto start = iter;
-
-  // Make sure we have some tokens to parse.
-  if (iter == token_stream.tokens->end()) {
-    return memo_error<Poi::Binding>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        "No binding to parse.",
-        pool.find(token_stream.source_name),
-        pool.find(token_stream.source),
-        ErrorConfidence::LOW
-      )
-    );
-  }
-
-  // Parse the Pattern.
-  auto pattern = ParseResult<Poi::Pattern>(
-    std::make_shared<ParseError>(
-      "No pattern found for this binding.",
-      pool.find(start->source_name),
-      pool.find(start->source),
-      start->start_pos,
-      iter->end_pos,
-      ErrorConfidence::LOW
-    )
-  ).choose(parse_pattern(memo, pool, token_stream, environment, iter));
-  if (pattern.error) {
-    return memo_error<Poi::Binding>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        pattern.error->what(),
-        ErrorConfidence::LOW
-      )
-    );
-  }
-  iter = pattern.next;
-
-  // Parse the EQUALS.
-  if (
-    iter == token_stream.tokens->end() ||
-    iter->type != Poi::TokenType::EQUALS
+  ParseResult<Binding> parse_binding(
+    MemoMap &memo,
+    const StringPool &pool,
+    const TokenStream &token_stream,
+    const std::unordered_set<std::size_t> &environment,
+    std::vector<Token>::const_iterator iter
   ) {
-    return memo_error<Poi::Binding>(
-      memo,
-      key,
+    // Check if we can reuse a memoized result.
+    auto key = memo_key(MemoType::BINDING, iter);
+    auto memo_result = memo.find(key);
+    if (memo_result != memo.end()) {
+      return memo_result->second.downcast<Binding>();
+    }
+
+    // Mark the beginning of the Binding.
+    auto start = iter;
+
+    // Make sure we have some tokens to parse.
+    if (iter == token_stream.tokens->end()) {
+      return memo_error<Binding>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          "No binding to parse.",
+          pool.find(token_stream.source_name),
+          pool.find(token_stream.source),
+          ErrorConfidence::LOW
+        )
+      );
+    }
+
+    // Parse the Pattern.
+    auto pattern = ParseResult<Pattern>(
       std::make_shared<ParseError>(
-        "Expected '=' in this binding.",
-        pool.find(start->source_name),
-        pool.find(start->source),
-        start->start_pos,
-        (iter - 1)->end_pos,
-        ErrorConfidence::LOW
-      )
-    );
-  }
-  ++iter;
-
-  // Add the pattern variables to the environment.
-  auto new_environment = environment;
-  new_environment.insert(
-    pattern.node->variables->begin(),
-    pattern.node->variables->end()
-  );
-
-  // Parse the definition.
-  auto definition = ParseResult<Poi::Term>(
-    std::make_shared<ParseError>(
-      "No definition found for this binding.",
-      pool.find(start->source_name),
-      pool.find(start->source),
-      start->start_pos,
-      (iter - 1)->end_pos,
-      ErrorConfidence::LOW
-    )
-  ).choose(parse_term(memo, pool, token_stream, new_environment, iter));
-  if (definition.error) {
-    return memo_error<Poi::Binding>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        definition.error->what(),
-        ErrorConfidence::HIGH
-      )
-    );
-  }
-  iter = definition.next;
-
-  // Parse the SEPARATOR.
-  if (
-    iter == token_stream.tokens->end() ||
-    iter->type != Poi::TokenType::SEPARATOR
-  ) {
-    return memo_error<Poi::Binding>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        "Expected a body for this binding.",
-        pool.find(start->source_name),
-        pool.find(start->source),
-        start->start_pos,
-        (iter - 1)->end_pos,
-        ErrorConfidence::HIGH
-      )
-    );
-  }
-  ++iter;
-
-  // Parse the body.
-  auto body = ParseResult<Poi::Term>(
-    std::make_shared<ParseError>(
-      "No body found for this binding.",
-      pool.find(start->source_name),
-      pool.find(start->source),
-      start->start_pos,
-      (iter - 1)->end_pos,
-      ErrorConfidence::LOW
-    )
-  ).choose(parse_term(memo, pool, token_stream, new_environment, iter));
-  if (body.error) {
-    return memo_error<Poi::Binding>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        body.error->what(),
-        ErrorConfidence::HIGH
-      )
-    );
-  }
-  iter = body.next;
-
-  // Construct the Binding.
-  auto free_variables = std::make_shared<std::unordered_set<std::size_t>>();
-  free_variables->insert(
-    definition.node->free_variables->begin(),
-    definition.node->free_variables->end()
-  );
-  free_variables->insert(
-    body.node->free_variables->begin(),
-    body.node->free_variables->end()
-  );
-  for (auto &variable : *(pattern.node->variables)) {
-    free_variables->erase(variable);
-  }
-  auto binding = std::make_shared<Poi::Binding>(
-    start->source_name,
-    start->source,
-    start->start_pos,
-    (iter - 1)->end_pos,
-    free_variables,
-    pattern.node,
-    definition.node,
-    body.node
-  );
-
-  // Memoize and return the result.
-  return memo_success<Poi::Binding>(memo, key, binding, iter);
-}
-
-ParseResult<Poi::DataType> parse_data_type(
-  MemoMap &memo,
-  const Poi::StringPool &pool,
-  const Poi::TokenStream &token_stream,
-  const std::unordered_set<std::size_t> &environment,
-  std::vector<Poi::Token>::const_iterator iter
-) {
-  // Check if we can reuse a memoized result.
-  auto key = memo_key(MemoType::DATA_TYPE, iter);
-  auto memo_result = memo.find(key);
-  if (memo_result != memo.end()) {
-    return memo_result->second.downcast<Poi::DataType>();
-  }
-
-  // Mark the beginning of the DataType.
-  auto start = iter;
-
-  // Make sure we have some tokens to parse.
-  if (iter == token_stream.tokens->end()) {
-    return memo_error<Poi::DataType>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        "No data type to parse.",
-        pool.find(token_stream.source_name),
-        pool.find(token_stream.source),
-        ErrorConfidence::LOW
-      )
-    );
-  }
-
-  // Parse the LEFT_CURLY.
-  if (iter->type != Poi::TokenType::LEFT_CURLY) {
-    return memo_error<Poi::DataType>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        "Expected '{' to introduce a data type.",
+        "No pattern found for this binding.",
         pool.find(start->source_name),
         pool.find(start->source),
         start->start_pos,
         iter->end_pos,
         ErrorConfidence::LOW
       )
-    );
-  }
-  ++iter;
-
-  // Parse the constructors. Note that the lexical analyzer guarantees
-  // parentheses are matched.
-  auto constructor_names = std::make_shared<std::vector<std::size_t>>();
-  auto constructor_params = std::make_shared<
-    std::unordered_map<std::size_t, std::vector<std::size_t>>
-  >();
-  auto constructors = std::make_shared<
-    std::unordered_map<std::size_t, std::shared_ptr<const Poi::Term>>
-  >();
-  std::vector<std::shared_ptr<Poi::Data>> data_terms;
-  bool first = true;
-  while (iter->type != Poi::TokenType::RIGHT_CURLY) {
-    // Parse the SEPARATOR if applicable.
-    if (first) {
-      first = false;
-    } else {
-      ++iter;
-    }
-
-    // Mark the start of the constructor for nice error reporting.
-    auto constructor_start = iter;
-
-    // Parse the name of the constructor.
-    if (iter->type != Poi::TokenType::IDENTIFIER) {
-      return memo_error<Poi::DataType>(
+    ).choose(parse_pattern(memo, pool, token_stream, environment, iter));
+    if (pattern.error) {
+      return memo_error<Binding>(
         memo,
         key,
         std::make_shared<ParseError>(
-          "Invalid data constructor.",
-          pool.find(constructor_start->source_name),
-          pool.find(constructor_start->source),
-          constructor_start->start_pos,
-          iter->end_pos,
-          ErrorConfidence::MED
+          pattern.error->what(),
+          ErrorConfidence::LOW
         )
       );
     }
-    auto name = iter->literal;
+    iter = pattern.next;
+
+    // Parse the EQUALS.
+    if (
+      iter == token_stream.tokens->end() ||
+      iter->type != TokenType::EQUALS
+    ) {
+      return memo_error<Binding>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          "Expected '=' in this binding.",
+          pool.find(start->source_name),
+          pool.find(start->source),
+          start->start_pos,
+          (iter - 1)->end_pos,
+          ErrorConfidence::LOW
+        )
+      );
+    }
     ++iter;
 
-    // Parse the parameters.
-    std::vector<std::size_t> params;
-    std::unordered_set<std::size_t> params_set;
-    while (
-      iter->type != Poi::TokenType::SEPARATOR &&
-      iter->type != Poi::TokenType::RIGHT_CURLY
+    // Add the pattern variables to the environment.
+    auto new_environment = environment;
+    new_environment.insert(
+      pattern.node->variables->begin(),
+      pattern.node->variables->end()
+    );
+
+    // Parse the definition.
+    auto definition = ParseResult<Term>(
+      std::make_shared<ParseError>(
+        "No definition found for this binding.",
+        pool.find(start->source_name),
+        pool.find(start->source),
+        start->start_pos,
+        (iter - 1)->end_pos,
+        ErrorConfidence::LOW
+      )
+    ).choose(parse_term(memo, pool, token_stream, new_environment, iter));
+    if (definition.error) {
+      return memo_error<Binding>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          definition.error->what(),
+          ErrorConfidence::HIGH
+        )
+      );
+    }
+    iter = definition.next;
+
+    // Parse the SEPARATOR.
+    if (
+      iter == token_stream.tokens->end() ||
+      iter->type != TokenType::SEPARATOR
     ) {
-      if (iter->type != Poi::TokenType::IDENTIFIER) {
-        return memo_error<Poi::DataType>(
+      return memo_error<Binding>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          "Expected a body for this binding.",
+          pool.find(start->source_name),
+          pool.find(start->source),
+          start->start_pos,
+          (iter - 1)->end_pos,
+          ErrorConfidence::HIGH
+        )
+      );
+    }
+    ++iter;
+
+    // Parse the body.
+    auto body = ParseResult<Term>(
+      std::make_shared<ParseError>(
+        "No body found for this binding.",
+        pool.find(start->source_name),
+        pool.find(start->source),
+        start->start_pos,
+        (iter - 1)->end_pos,
+        ErrorConfidence::LOW
+      )
+    ).choose(parse_term(memo, pool, token_stream, new_environment, iter));
+    if (body.error) {
+      return memo_error<Binding>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          body.error->what(),
+          ErrorConfidence::HIGH
+        )
+      );
+    }
+    iter = body.next;
+
+    // Construct the Binding.
+    auto free_variables = std::make_shared<std::unordered_set<std::size_t>>();
+    free_variables->insert(
+      definition.node->free_variables->begin(),
+      definition.node->free_variables->end()
+    );
+    free_variables->insert(
+      body.node->free_variables->begin(),
+      body.node->free_variables->end()
+    );
+    for (auto &variable : *(pattern.node->variables)) {
+      free_variables->erase(variable);
+    }
+    auto binding = std::make_shared<Binding>(
+      start->source_name,
+      start->source,
+      start->start_pos,
+      (iter - 1)->end_pos,
+      free_variables,
+      pattern.node,
+      definition.node,
+      body.node
+    );
+
+    // Memoize and return the result.
+    return memo_success<Binding>(memo, key, binding, iter);
+  }
+
+  ParseResult<DataType> parse_data_type(
+    MemoMap &memo,
+    const StringPool &pool,
+    const TokenStream &token_stream,
+    const std::unordered_set<std::size_t> &environment,
+    std::vector<Token>::const_iterator iter
+  ) {
+    // Check if we can reuse a memoized result.
+    auto key = memo_key(MemoType::DATA_TYPE, iter);
+    auto memo_result = memo.find(key);
+    if (memo_result != memo.end()) {
+      return memo_result->second.downcast<DataType>();
+    }
+
+    // Mark the beginning of the DataType.
+    auto start = iter;
+
+    // Make sure we have some tokens to parse.
+    if (iter == token_stream.tokens->end()) {
+      return memo_error<DataType>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          "No data type to parse.",
+          pool.find(token_stream.source_name),
+          pool.find(token_stream.source),
+          ErrorConfidence::LOW
+        )
+      );
+    }
+
+    // Parse the LEFT_CURLY.
+    if (iter->type != TokenType::LEFT_CURLY) {
+      return memo_error<DataType>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          "Expected '{' to introduce a data type.",
+          pool.find(start->source_name),
+          pool.find(start->source),
+          start->start_pos,
+          iter->end_pos,
+          ErrorConfidence::LOW
+        )
+      );
+    }
+    ++iter;
+
+    // Parse the constructors. Note that the lexical analyzer guarantees
+    // parentheses are matched.
+    auto constructor_names = std::make_shared<std::vector<std::size_t>>();
+    auto constructor_params = std::make_shared<
+      std::unordered_map<std::size_t, std::vector<std::size_t>>
+    >();
+    auto constructors = std::make_shared<
+      std::unordered_map<std::size_t, std::shared_ptr<const Term>>
+    >();
+    std::vector<std::shared_ptr<Data>> data_terms;
+    bool first = true;
+    while (iter->type != TokenType::RIGHT_CURLY) {
+      // Parse the SEPARATOR if applicable.
+      if (first) {
+        first = false;
+      } else {
+        ++iter;
+      }
+
+      // Mark the start of the constructor for nice error reporting.
+      auto constructor_start = iter;
+
+      // Parse the name of the constructor.
+      if (iter->type != TokenType::IDENTIFIER) {
+        return memo_error<DataType>(
           memo,
           key,
           std::make_shared<ParseError>(
@@ -1453,265 +1436,246 @@ ParseResult<Poi::DataType> parse_data_type(
           )
         );
       }
-      auto parameter = iter->literal;
+      auto name = iter->literal;
+      ++iter;
 
-      // Check whether a parameter of this name already exists.
-      if (params_set.find(parameter) != params_set.end()) {
-        return memo_error<Poi::DataType>(
+      // Parse the parameters.
+      std::vector<std::size_t> params;
+      std::unordered_set<std::size_t> params_set;
+      while (
+        iter->type != TokenType::SEPARATOR &&
+        iter->type != TokenType::RIGHT_CURLY
+      ) {
+        if (iter->type != TokenType::IDENTIFIER) {
+          return memo_error<DataType>(
+            memo,
+            key,
+            std::make_shared<ParseError>(
+              "Invalid data constructor.",
+              pool.find(constructor_start->source_name),
+              pool.find(constructor_start->source),
+              constructor_start->start_pos,
+              iter->end_pos,
+              ErrorConfidence::MED
+            )
+          );
+        }
+        auto parameter = iter->literal;
+
+        // Check whether a parameter of this name already exists.
+        if (params_set.find(parameter) != params_set.end()) {
+          return memo_error<DataType>(
+            memo,
+            key,
+            std::make_shared<ParseError>(
+              "Duplicate parameter '" +
+                 pool.find(parameter) +
+                 "' in data constructor '" +
+                 pool.find(name) +
+                 "'.",
+              pool.find(iter->source_name),
+              pool.find(iter->source),
+              iter->start_pos,
+              iter->end_pos,
+              ErrorConfidence::MED
+            )
+          );
+        }
+
+        params.push_back(parameter);
+        params_set.insert(parameter);
+        ++iter;
+      }
+
+      // Check whether a constructor of this name already exists.
+      auto existing_constructor = constructor_params->find(name);
+      if (existing_constructor != constructor_params->end()) {
+        return memo_error<DataType>(
           memo,
           key,
           std::make_shared<ParseError>(
-            "Duplicate parameter '" +
-               pool.find(parameter) +
-               "' in data constructor '" +
-               pool.find(name) +
-               "'.",
-            pool.find(iter->source_name),
-            pool.find(iter->source),
-            iter->start_pos,
-            iter->end_pos,
+            "Duplicate constructor '" +
+             pool.find(name) +
+             "' in data type.",
+            pool.find(constructor_start->source_name),
+            pool.find(constructor_start->source),
+            constructor_start->start_pos,
+            (iter - 1)->end_pos,
             ErrorConfidence::MED
           )
         );
       }
 
-      params.push_back(parameter);
-      params_set.insert(parameter);
-      ++iter;
-    }
+      // Register the constructor name and parameters.
+      constructor_names->push_back(name);
+      constructor_params->insert({ name, params });
 
-    // Check whether a constructor of this name already exists.
-    auto existing_constructor = constructor_params->find(name);
-    if (existing_constructor != constructor_params->end()) {
-      return memo_error<Poi::DataType>(
-        memo,
-        key,
-        std::make_shared<ParseError>(
-          "Duplicate constructor '" +
-           pool.find(name) +
-           "' in data type.",
-          pool.find(constructor_start->source_name),
-          pool.find(constructor_start->source),
-          constructor_start->start_pos,
-          (iter - 1)->end_pos,
-          ErrorConfidence::MED
-        )
-      );
-    }
-
-    // Register the constructor name and parameters.
-    constructor_names->push_back(name);
-    constructor_params->insert({ name, params });
-
-    // Construct the constructor.
-    auto free_variables = std::make_shared<std::unordered_set<std::size_t>>();
-    free_variables->insert(
-      params.begin(),
-      params.end()
-    );
-    auto data_term = std::make_shared<Poi::Data>(
-      constructor_start->source_name,
-      constructor_start->source,
-      constructor_start->start_pos,
-      (iter - 1)->end_pos,
-      free_variables,
-      std::weak_ptr<Poi::DataType>(),
-      name
-    );
-    data_terms.push_back(data_term);
-    auto constructor = std::static_pointer_cast<Poi::Term>(data_term);
-    for (auto iter = params.rbegin(); iter != params.rend(); ++iter) {
-      free_variables = std::make_shared<std::unordered_set<std::size_t>>();
-      free_variables->insert(
-        constructor->free_variables->begin(),
-        constructor->free_variables->end()
-      );
-      free_variables->erase(*iter);
-      auto variables = std::make_shared<
-        const std::unordered_set<std::size_t>
-      >();
-      std::const_pointer_cast<
+      // Construct the constructor.
+      auto free_variables = std::make_shared<
         std::unordered_set<std::size_t>
-      >(variables)->insert(*iter);
-      auto variable_pattern = std::make_shared<Poi::VariablePattern>(
-        constructor->source_name,
-        constructor->source,
-        constructor->start_pos,
-        constructor->end_pos,
-        *iter,
-        variables
+      >();
+      free_variables->insert(
+        params.begin(),
+        params.end()
       );
-      constructor = std::static_pointer_cast<Poi::Term>(
-        std::make_shared<Poi::Function>(
+      auto data_term = std::make_shared<Data>(
+        constructor_start->source_name,
+        constructor_start->source,
+        constructor_start->start_pos,
+        (iter - 1)->end_pos,
+        free_variables,
+        std::weak_ptr<DataType>(),
+        name
+      );
+      data_terms.push_back(data_term);
+      auto constructor = std::static_pointer_cast<Term>(data_term);
+      for (auto iter = params.rbegin(); iter != params.rend(); ++iter) {
+        free_variables = std::make_shared<std::unordered_set<std::size_t>>();
+        free_variables->insert(
+          constructor->free_variables->begin(),
+          constructor->free_variables->end()
+        );
+        free_variables->erase(*iter);
+        auto variables = std::make_shared<
+          const std::unordered_set<std::size_t>
+        >();
+        std::const_pointer_cast<
+          std::unordered_set<std::size_t>
+        >(variables)->insert(*iter);
+        auto variable_pattern = std::make_shared<VariablePattern>(
           constructor->source_name,
           constructor->source,
           constructor->start_pos,
           constructor->end_pos,
-          free_variables,
-          variable_pattern,
-          constructor
+          *iter,
+          variables
+        );
+        constructor = std::static_pointer_cast<Term>(
+          std::make_shared<Function>(
+            constructor->source_name,
+            constructor->source,
+            constructor->start_pos,
+            constructor->end_pos,
+            free_variables,
+            variable_pattern,
+            constructor
+          )
+        );
+      }
+      constructors->insert({ name, constructor });
+    }
+
+    // Skip the closing RIGHT_CURLY.
+    ++iter;
+
+    // Construct the DataType.
+    auto data_type = std::make_shared<DataType>(
+      start->source_name,
+      start->source,
+      start->start_pos,
+      (iter - 1)->end_pos,
+      std::make_shared<std::unordered_set<std::size_t>>(),
+      constructor_names,
+      constructor_params,
+      constructors
+    );
+
+    // "Tie the knot" by giving the Data terms a reference to the DataType.
+    for (auto &data_term : data_terms) {
+      const_cast<std::weak_ptr<const DataType> &>(
+        data_term->data_type
+      ) = std::weak_ptr<const DataType>(data_type);
+    }
+
+    // Memoize and return the result.
+    return memo_success<DataType>(memo, key, data_type, iter);
+  }
+
+  ParseResult<Member> parse_member(
+    MemoMap &memo,
+    const StringPool &pool,
+    const TokenStream &token_stream,
+    const std::unordered_set<std::size_t> &environment,
+    std::vector<Token>::const_iterator iter
+  ) {
+    // Check if we can reuse a memoized result.
+    auto key = memo_key(MemoType::MEMBER, iter);
+    auto memo_result = memo.find(key);
+    if (memo_result != memo.end()) {
+      return memo_result->second.downcast<Member>();
+    }
+
+    // Mark the beginning of the Member.
+    auto start = iter;
+
+    // Make sure we have some tokens to parse.
+    if (iter == token_stream.tokens->end()) {
+      return memo_error<Member>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          "No member to parse.",
+          pool.find(token_stream.source_name),
+          pool.find(token_stream.source),
+          ErrorConfidence::LOW
         )
       );
     }
-    constructors->insert({ name, constructor });
-  }
 
-  // Skip the closing RIGHT_CURLY.
-  ++iter;
-
-  // Construct the DataType.
-  auto data_type = std::make_shared<Poi::DataType>(
-    start->source_name,
-    start->source,
-    start->start_pos,
-    (iter - 1)->end_pos,
-    std::make_shared<std::unordered_set<std::size_t>>(),
-    constructor_names,
-    constructor_params,
-    constructors
-  );
-
-  // "Tie the knot" by giving the Data terms a reference to the DataType.
-  for (auto &data_term : data_terms) {
-    const_cast<std::weak_ptr<const Poi::DataType> &>(
-      data_term->data_type
-    ) = std::weak_ptr<const Poi::DataType>(data_type);
-  }
-
-  // Memoize and return the result.
-  return memo_success<Poi::DataType>(memo, key, data_type, iter);
-}
-
-ParseResult<Poi::Member> parse_member(
-  MemoMap &memo,
-  const Poi::StringPool &pool,
-  const Poi::TokenStream &token_stream,
-  const std::unordered_set<std::size_t> &environment,
-  std::vector<Poi::Token>::const_iterator iter
-) {
-  // Check if we can reuse a memoized result.
-  auto key = memo_key(MemoType::MEMBER, iter);
-  auto memo_result = memo.find(key);
-  if (memo_result != memo.end()) {
-    return memo_result->second.downcast<Poi::Member>();
-  }
-
-  // Mark the beginning of the Member.
-  auto start = iter;
-
-  // Make sure we have some tokens to parse.
-  if (iter == token_stream.tokens->end()) {
-    return memo_error<Poi::Member>(
-      memo,
-      key,
+    // Parse the object.
+    auto object = ParseResult<Term>(
       std::make_shared<ParseError>(
-        "No member to parse.",
-        pool.find(token_stream.source_name),
-        pool.find(token_stream.source),
+        "Unexpected token.",
+        pool.find(iter->source_name),
+        pool.find(iter->source),
+        iter->start_pos,
+        iter->end_pos,
         ErrorConfidence::LOW
       )
+    ).choose(
+      parse_variable(
+        memo, pool, token_stream, environment, iter
+      ).upcast<Term>()
+    ).choose(
+      parse_data_type(
+        memo, pool, token_stream, environment, iter
+      ).upcast<Term>()
+    ).choose(
+      parse_group(
+        memo, pool, token_stream, environment, iter
+      ).upcast<Term>()
     );
-  }
+    if (object.error) {
+      return memo_error<Member>(memo, key, object.error);
+    }
+    iter = object.next;
 
-  // Parse the object.
-  auto object = ParseResult<Poi::Term>(
-    std::make_shared<ParseError>(
-      "Unexpected token.",
-      pool.find(iter->source_name),
-      pool.find(iter->source),
-      iter->start_pos,
-      iter->end_pos,
-      ErrorConfidence::LOW
-    )
-  ).choose(
-    parse_variable(
-      memo, pool, token_stream, environment, iter
-    ).upcast<Poi::Term>()
-  ).choose(
-    parse_data_type(
-      memo, pool, token_stream, environment, iter
-    ).upcast<Poi::Term>()
-  ).choose(
-    parse_group(
-      memo, pool, token_stream, environment, iter
-    ).upcast<Poi::Term>()
-  );
-  if (object.error) {
-    return memo_error<Poi::Member>(memo, key, object.error);
-  }
-  iter = object.next;
-
-  // Parse the DOT.
-  if (
-    iter == token_stream.tokens->end() ||
-    iter->type != Poi::TokenType::DOT
-  ) {
-    return memo_error<Poi::Member>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        "Expected '.' for this member access.",
-        pool.find(start->source_name),
-        pool.find(start->source),
-        start->start_pos,
-        (iter - 1)->end_pos,
-        ErrorConfidence::LOW
-      )
-    );
-  }
-  ++iter;
-
-  // Parse the IDENTIFIER.
-  if (
-    iter == token_stream.tokens->end() ||
-    iter->type != Poi::TokenType::IDENTIFIER
-  ) {
-    return memo_error<Poi::Member>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        "Invalid member access.",
-        pool.find(start->source_name),
-        pool.find(start->source),
-        start->start_pos,
-        (iter - 1)->end_pos,
-        ErrorConfidence::HIGH
-      )
-    );
-  }
-  auto field_name = iter->literal;
-  ++iter;
-
-  // Construct the Member.
-  auto free_variables = std::make_shared<std::unordered_set<std::size_t>>();
-  free_variables->insert(
-    object.node->free_variables->begin(),
-    object.node->free_variables->end()
-  );
-  auto member = std::make_shared<Poi::Member>(
-    start->source_name,
-    start->source,
-    start->start_pos,
-    (iter - 1)->end_pos,
-    free_variables,
-    object.node,
-    field_name
-  );
-
-  // Check for additional member accesses.
-  while (
-    iter != token_stream.tokens->end() &&
-    iter->type == Poi::TokenType::DOT
-  ) {
-    // Skip the DOT.
+    // Parse the DOT.
+    if (
+      iter == token_stream.tokens->end() ||
+      iter->type != TokenType::DOT
+    ) {
+      return memo_error<Member>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          "Expected '.' for this member access.",
+          pool.find(start->source_name),
+          pool.find(start->source),
+          start->start_pos,
+          (iter - 1)->end_pos,
+          ErrorConfidence::LOW
+        )
+      );
+    }
     ++iter;
 
     // Parse the IDENTIFIER.
     if (
       iter == token_stream.tokens->end() ||
-      iter->type != Poi::TokenType::IDENTIFIER
+      iter->type != TokenType::IDENTIFIER
     ) {
-      return memo_error<Poi::Member>(
+      return memo_error<Member>(
         memo,
         key,
         std::make_shared<ParseError>(
@@ -1724,325 +1688,371 @@ ParseResult<Poi::Member> parse_member(
         )
       );
     }
-    field_name = iter->literal;
+    auto field_name = iter->literal;
     ++iter;
 
-    // Construct the new Member.
-    free_variables = std::make_shared<std::unordered_set<std::size_t>>();
+    // Construct the Member.
+    auto free_variables = std::make_shared<std::unordered_set<std::size_t>>();
     free_variables->insert(
-      member->free_variables->begin(),
-      member->free_variables->end()
+      object.node->free_variables->begin(),
+      object.node->free_variables->end()
     );
-    member = std::make_shared<Poi::Member>(
+    auto member = std::make_shared<Member>(
       start->source_name,
       start->source,
       start->start_pos,
       (iter - 1)->end_pos,
       free_variables,
-      member,
+      object.node,
       field_name
     );
-  }
 
-  // Memoize and return the result.
-  return memo_success<Poi::Member>(memo, key, member, iter);
-}
+    // Check for additional member accesses.
+    while (
+      iter != token_stream.tokens->end() &&
+      iter->type == TokenType::DOT
+    ) {
+      // Skip the DOT.
+      ++iter;
 
-ParseResult<Poi::Match> parse_match(
-  MemoMap &memo,
-  const Poi::StringPool &pool,
-  const Poi::TokenStream &token_stream,
-  const std::unordered_set<std::size_t> &environment,
-  std::vector<Poi::Token>::const_iterator iter
-) {
-  // Check if we can reuse a memoized result.
-  auto key = memo_key(MemoType::MATCH, iter);
-  auto memo_result = memo.find(key);
-  if (memo_result != memo.end()) {
-    return memo_result->second.downcast<Poi::Match>();
-  }
-
-  // Mark the beginning of the Match.
-  auto start = iter;
-
-  // Make sure we have some tokens to parse.
-  if (iter == token_stream.tokens->end()) {
-    return memo_error<Poi::Match>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        "No match expression to parse.",
-        pool.find(token_stream.source_name),
-        pool.find(token_stream.source),
-        ErrorConfidence::LOW
-      )
-    );
-  }
-
-  // Parse the MATCH.
-  if (iter->type != Poi::TokenType::MATCH) {
-    return memo_error<Poi::Match>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        "Expected 'match' to start this match expression.",
-        pool.find(start->source_name),
-        pool.find(start->source),
-        start->start_pos,
-        iter->end_pos,
-        ErrorConfidence::LOW
-      )
-    );
-  }
-  ++iter;
-
-  // Parse the discriminee.
-  auto discriminee = parse_term(
-    memo, pool, token_stream, environment, iter
-  ).choose(
-    ParseResult<Poi::Term>(
-      std::make_shared<ParseError>(
-        "No discriminee found for this match expression.",
-        pool.find(start->source_name),
-        pool.find(start->source),
-        start->start_pos,
-        (iter - 1)->end_pos,
-        ErrorConfidence::LOW
-      )
-    )
-  );
-  if (discriminee.error) {
-    return memo_error<Poi::Match>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        discriminee.error->what(),
-        ErrorConfidence::HIGH
-      )
-    );
-  }
-  auto free_variables = std::make_shared<std::unordered_set<std::size_t>>();
-  free_variables->insert(
-    discriminee.node->free_variables->begin(),
-    discriminee.node->free_variables->end()
-  );
-  iter = discriminee.next;
-
-  // Parse the LEFT_CURLY.
-  if (
-    iter == token_stream.tokens->end() ||
-    iter->type != Poi::TokenType::LEFT_CURLY
-  ) {
-    return memo_error<Poi::Match>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        "Expected '{' to begin the cases for this match expression.",
-        pool.find(start->source_name),
-        pool.find(start->source),
-        start->start_pos,
-        (iter - 1)->end_pos,
-        ErrorConfidence::HIGH
-      )
-    );
-  }
-  ++iter;
-
-  // Parse the cases. Note that the lexical analyzer guarantees
-  // curly braces are matched.
-  auto cases = std::make_shared<
-    std::vector<std::shared_ptr<const Poi::Function>>
-  >();
-  bool first = true;
-  while (iter->type != Poi::TokenType::RIGHT_CURLY) {
-    // Parse the SEPARATOR if applicable.
-    if (first) {
-      first = false;
-    } else {
-      if (iter->type != Poi::TokenType::SEPARATOR) {
-        return memo_error<Poi::Match>(
+      // Parse the IDENTIFIER.
+      if (
+        iter == token_stream.tokens->end() ||
+        iter->type != TokenType::IDENTIFIER
+      ) {
+        return memo_error<Member>(
           memo,
           key,
           std::make_shared<ParseError>(
-            "Invalid case in this match expression.",
-            pool.find(iter->source_name),
-            pool.find(iter->source),
-            iter->start_pos,
-            iter->end_pos,
+            "Invalid member access.",
+            pool.find(start->source_name),
+            pool.find(start->source),
+            start->start_pos,
+            (iter - 1)->end_pos,
             ErrorConfidence::HIGH
           )
         );
       }
+      field_name = iter->literal;
       ++iter;
+
+      // Construct the new Member.
+      free_variables = std::make_shared<std::unordered_set<std::size_t>>();
+      free_variables->insert(
+        member->free_variables->begin(),
+        member->free_variables->end()
+      );
+      member = std::make_shared<Member>(
+        start->source_name,
+        start->source,
+        start->start_pos,
+        (iter - 1)->end_pos,
+        free_variables,
+        member,
+        field_name
+      );
     }
 
-    // Parse the case.
-    auto c = ParseResult<Poi::Function>(
-      std::make_shared<ParseError>(
-        "Invalid case in this match expression.",
-        pool.find(iter->source_name),
-        pool.find(iter->source),
-        iter->start_pos,
-        iter->end_pos,
-        ErrorConfidence::LOW
-      )
-    ).choose(parse_function(memo, pool, token_stream, environment, iter));
-    if (c.error) {
-      return memo_error<Poi::Match>(
+    // Memoize and return the result.
+    return memo_success<Member>(memo, key, member, iter);
+  }
+
+  ParseResult<Match> parse_match(
+    MemoMap &memo,
+    const StringPool &pool,
+    const TokenStream &token_stream,
+    const std::unordered_set<std::size_t> &environment,
+    std::vector<Token>::const_iterator iter
+  ) {
+    // Check if we can reuse a memoized result.
+    auto key = memo_key(MemoType::MATCH, iter);
+    auto memo_result = memo.find(key);
+    if (memo_result != memo.end()) {
+      return memo_result->second.downcast<Match>();
+    }
+
+    // Mark the beginning of the Match.
+    auto start = iter;
+
+    // Make sure we have some tokens to parse.
+    if (iter == token_stream.tokens->end()) {
+      return memo_error<Match>(
         memo,
         key,
         std::make_shared<ParseError>(
-          c.error->what(),
+          "No match expression to parse.",
+          pool.find(token_stream.source_name),
+          pool.find(token_stream.source),
+          ErrorConfidence::LOW
+        )
+      );
+    }
+
+    // Parse the MATCH.
+    if (iter->type != TokenType::MATCH) {
+      return memo_error<Match>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          "Expected 'match' to start this match expression.",
+          pool.find(start->source_name),
+          pool.find(start->source),
+          start->start_pos,
+          iter->end_pos,
+          ErrorConfidence::LOW
+        )
+      );
+    }
+    ++iter;
+
+    // Parse the discriminee.
+    auto discriminee = parse_term(
+      memo, pool, token_stream, environment, iter
+    ).choose(
+      ParseResult<Term>(
+        std::make_shared<ParseError>(
+          "No discriminee found for this match expression.",
+          pool.find(start->source_name),
+          pool.find(start->source),
+          start->start_pos,
+          (iter - 1)->end_pos,
+          ErrorConfidence::LOW
+        )
+      )
+    );
+    if (discriminee.error) {
+      return memo_error<Match>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          discriminee.error->what(),
           ErrorConfidence::HIGH
         )
       );
     }
+    auto free_variables = std::make_shared<std::unordered_set<std::size_t>>();
     free_variables->insert(
-      c.node->free_variables->begin(),
-      c.node->free_variables->end()
+      discriminee.node->free_variables->begin(),
+      discriminee.node->free_variables->end()
     );
-    cases->push_back(c.node);
-    iter = c.next;
-  }
+    iter = discriminee.next;
 
-  // Make sure we have at least one case.
-  if (cases->empty()) {
-    return memo_error<Poi::Match>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        "A match expression must have at least one case.",
-        pool.find(start->source_name),
-        pool.find(start->source),
-        start->start_pos,
-        iter->end_pos,
-        ErrorConfidence::HIGH
-      )
+    // Parse the LEFT_CURLY.
+    if (
+      iter == token_stream.tokens->end() ||
+      iter->type != TokenType::LEFT_CURLY
+    ) {
+      return memo_error<Match>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          "Expected '{' to begin the cases for this match expression.",
+          pool.find(start->source_name),
+          pool.find(start->source),
+          start->start_pos,
+          (iter - 1)->end_pos,
+          ErrorConfidence::HIGH
+        )
+      );
+    }
+    ++iter;
+
+    // Parse the cases. Note that the lexical analyzer guarantees
+    // curly braces are matched.
+    auto cases = std::make_shared<
+      std::vector<std::shared_ptr<const Function>>
+    >();
+    bool first = true;
+    while (iter->type != TokenType::RIGHT_CURLY) {
+      // Parse the SEPARATOR if applicable.
+      if (first) {
+        first = false;
+      } else {
+        if (iter->type != TokenType::SEPARATOR) {
+          return memo_error<Match>(
+            memo,
+            key,
+            std::make_shared<ParseError>(
+              "Invalid case in this match expression.",
+              pool.find(iter->source_name),
+              pool.find(iter->source),
+              iter->start_pos,
+              iter->end_pos,
+              ErrorConfidence::HIGH
+            )
+          );
+        }
+        ++iter;
+      }
+
+      // Parse the case.
+      auto c = ParseResult<Function>(
+        std::make_shared<ParseError>(
+          "Invalid case in this match expression.",
+          pool.find(iter->source_name),
+          pool.find(iter->source),
+          iter->start_pos,
+          iter->end_pos,
+          ErrorConfidence::LOW
+        )
+      ).choose(parse_function(memo, pool, token_stream, environment, iter));
+      if (c.error) {
+        return memo_error<Match>(
+          memo,
+          key,
+          std::make_shared<ParseError>(
+            c.error->what(),
+            ErrorConfidence::HIGH
+          )
+        );
+      }
+      free_variables->insert(
+        c.node->free_variables->begin(),
+        c.node->free_variables->end()
+      );
+      cases->push_back(c.node);
+      iter = c.next;
+    }
+
+    // Make sure we have at least one case.
+    if (cases->empty()) {
+      return memo_error<Match>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          "A match expression must have at least one case.",
+          pool.find(start->source_name),
+          pool.find(start->source),
+          start->start_pos,
+          iter->end_pos,
+          ErrorConfidence::HIGH
+        )
+      );
+    }
+
+    // Skip the closing RIGHT_CURLY.
+    ++iter;
+
+    // Construct the Match.
+    auto match = std::make_shared<Match>(
+      start->source_name,
+      start->source,
+      start->start_pos,
+      (iter - 1)->end_pos,
+      free_variables,
+      discriminee.node,
+      cases
     );
+
+    // Memoize and return the result.
+    return memo_success<Match>(memo, key, match, iter);
   }
 
-  // Skip the closing RIGHT_CURLY.
-  ++iter;
-
-  // Construct the Match.
-  auto match = std::make_shared<Poi::Match>(
-    start->source_name,
-    start->source,
-    start->start_pos,
-    (iter - 1)->end_pos,
-    free_variables,
-    discriminee.node,
-    cases
-  );
-
-  // Memoize and return the result.
-  return memo_success<Poi::Match>(memo, key, match, iter);
-}
-
-ParseResult<Poi::Term> parse_group(
-  MemoMap &memo,
-  const Poi::StringPool &pool,
-  const Poi::TokenStream &token_stream,
-  const std::unordered_set<std::size_t> &environment,
-  std::vector<Poi::Token>::const_iterator iter
-) {
-  // Check if we can reuse a memoized result.
-  auto key = memo_key(MemoType::GROUP, iter);
-  auto memo_result = memo.find(key);
-  if (memo_result != memo.end()) {
-    return memo_result->second.downcast<Poi::Term>();
-  }
-
-  // Mark the beginning of the Group.
-  auto start = iter;
-
-  // Make sure we have some tokens to parse.
-  if (iter == token_stream.tokens->end()) {
-    return memo_error<Poi::Term>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        "No group to parse.",
-        pool.find(token_stream.source_name),
-        pool.find(token_stream.source),
-        ErrorConfidence::LOW
-      )
-    );
-  }
-
-  // Parse the LEFT_PAREN.
-  if (iter->type != Poi::TokenType::LEFT_PAREN) {
-    return memo_error<Poi::Term>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        "Expected '(' to start this group.",
-        pool.find(start->source_name),
-        pool.find(start->source),
-        start->start_pos,
-        iter->end_pos,
-        ErrorConfidence::LOW
-      )
-    );
-  }
-  ++iter;
-
-  // Parse the body.
-  auto body = parse_term(
-    memo, pool, token_stream, environment, iter
-  ).choose(
-    ParseResult<Poi::Term>(
-      std::make_shared<ParseError>(
-        "No body found for this group.",
-        pool.find(start->source_name),
-        pool.find(start->source),
-        start->start_pos,
-        (iter - 1)->end_pos,
-        ErrorConfidence::LOW
-      )
-    )
-  );
-  if (body.error) {
-    return memo_error<Poi::Term>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        body.error->what(),
-        ErrorConfidence::HIGH
-      )
-    );
-  }
-  iter = body.next;
-
-  // Parse the RIGHT_PAREN.
-  if (
-    iter == token_stream.tokens->end() ||
-    iter->type != Poi::TokenType::RIGHT_PAREN
+  ParseResult<Term> parse_group(
+    MemoMap &memo,
+    const StringPool &pool,
+    const TokenStream &token_stream,
+    const std::unordered_set<std::size_t> &environment,
+    std::vector<Token>::const_iterator iter
   ) {
-    return memo_error<Poi::Term>(
-      memo,
-      key,
-      std::make_shared<ParseError>(
-        "Expected ')' to close this group.",
-        pool.find(start->source_name),
-        pool.find(start->source),
-        start->start_pos,
-        (iter - 1)->end_pos,
-        ErrorConfidence::HIGH
+    // Check if we can reuse a memoized result.
+    auto key = memo_key(MemoType::GROUP, iter);
+    auto memo_result = memo.find(key);
+    if (memo_result != memo.end()) {
+      return memo_result->second.downcast<Term>();
+    }
+
+    // Mark the beginning of the Group.
+    auto start = iter;
+
+    // Make sure we have some tokens to parse.
+    if (iter == token_stream.tokens->end()) {
+      return memo_error<Term>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          "No group to parse.",
+          pool.find(token_stream.source_name),
+          pool.find(token_stream.source),
+          ErrorConfidence::LOW
+        )
+      );
+    }
+
+    // Parse the LEFT_PAREN.
+    if (iter->type != TokenType::LEFT_PAREN) {
+      return memo_error<Term>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          "Expected '(' to start this group.",
+          pool.find(start->source_name),
+          pool.find(start->source),
+          start->start_pos,
+          iter->end_pos,
+          ErrorConfidence::LOW
+        )
+      );
+    }
+    ++iter;
+
+    // Parse the body.
+    auto body = parse_term(
+      memo, pool, token_stream, environment, iter
+    ).choose(
+      ParseResult<Term>(
+        std::make_shared<ParseError>(
+          "No body found for this group.",
+          pool.find(start->source_name),
+          pool.find(start->source),
+          start->start_pos,
+          (iter - 1)->end_pos,
+          ErrorConfidence::LOW
+        )
       )
     );
+    if (body.error) {
+      return memo_error<Term>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          body.error->what(),
+          ErrorConfidence::HIGH
+        )
+      );
+    }
+    iter = body.next;
+
+    // Parse the RIGHT_PAREN.
+    if (
+      iter == token_stream.tokens->end() ||
+      iter->type != TokenType::RIGHT_PAREN
+    ) {
+      return memo_error<Term>(
+        memo,
+        key,
+        std::make_shared<ParseError>(
+          "Expected ')' to close this group.",
+          pool.find(start->source_name),
+          pool.find(start->source),
+          start->start_pos,
+          (iter - 1)->end_pos,
+          ErrorConfidence::HIGH
+        )
+      );
+    }
+    ++iter;
+
+    // Modify the body's token span to include the parentheses. This is
+    // important because some Nodes get their spans from their children, and it
+    // would be akward (for example) if the last child of a Node were a Group
+    // and we didn't include the closing parenthesis.
+    const_cast<std::size_t &>(body.node->start_pos) = start->start_pos;
+    const_cast<std::size_t &>(body.node->end_pos) = (iter - 1)->end_pos;
+
+    // Memoize and return the result.
+    return memo_success<Term>(memo, key, body.node, iter);
   }
-  ++iter;
-
-  // Modify the body's token span to include the parentheses. This is
-  // important because some Nodes get their spans from their children, and it
-  // would be akward (for example) if the last child of a Node were a Group
-  // and we didn't include the closing parenthesis.
-  const_cast<std::size_t &>(body.node->start_pos) = start->start_pos;
-  const_cast<std::size_t &>(body.node->end_pos) = (iter - 1)->end_pos;
-
-  // Memoize and return the result.
-  return memo_success<Poi::Term>(memo, key, body.node, iter);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -2,11 +2,13 @@
 #include <poi/tokenizer.h>
 #include <unordered_map>
 
-enum class LineContinuationStatus {
-  LCS_DEFAULT,
-  LCS_WAIT_FOR_NEWLINE,
-  LCS_WAIT_FOR_TOKEN
-};
+namespace Poi {
+  enum class LineContinuationStatus {
+    LCS_DEFAULT,
+    LCS_WAIT_FOR_NEWLINE,
+    LCS_WAIT_FOR_TOKEN
+  };
+}
 
 Poi::TokenStream Poi::tokenize(
   std::size_t source_name,

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -7,7 +7,7 @@ namespace Poi {
 }
 
 std::string Poi::Value::show(std::size_t depth) const {
-  if (depth > Poi::max_value_show_depth) {
+  if (depth > max_value_show_depth) {
     return "...";
   }
 


### PR DESCRIPTION
Make sure all global definitions except those in main.cpp are in the `Poi` namespace. Now we can be confident that Poi will be able to link against any other code without naming conflicts.

**Status:** Ready

**Fixes:** N/A
