### PR TITLE
Add stack traces

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -126,23 +126,25 @@ int main(int argc, char * argv[]) {
     }
 
     // Compile the AST into IR.
-    auto block = Poi::compile_ast_to_ir(term);
+    auto ir_block = Poi::compile_ast_to_ir(term);
     if (cli_action == CliAction::EMIT_IR) {
-      std::cout << block->show();
+      std::cout << ir_block->show();
       return 0;
     }
 
     // Compile the IR into BC.
-    auto bytecode = compile_ir_to_bc(*block);
+    auto bytecode_block = compile_ir_to_bc(*ir_block);
     if (cli_action == CliAction::EMIT_BC) {
-      for (std::size_t i = 0; i < bytecode->size(); ++i) {
-        std::cout << i << " " << bytecode->at(i).show() << "\n";
-      }
+      std::cout << bytecode_block->show();
       return 0;
     }
 
     // Run the program by interpreting the BC.
-    auto result = Poi::interpret(&bytecode->at(0), block->frame_size());
+    auto result = Poi::interpret(
+      ir_block->frame_size(),
+      *bytecode_block,
+      pool
+    );
     std::cout << result->show(0) << "\n";
   } catch(Poi::Error &e) {
     // There was an error. Print it and exit.

--- a/include/ast.h
+++ b/include/ast.h
@@ -13,7 +13,7 @@
 #include <vector>
 
 namespace Poi {
-  class BasicBlock; // Declared in poi/ir.h
+  class IrBlock; // Declared in poi/ir.h
 
   class VariableInfo {
   public:
@@ -106,7 +106,7 @@ namespace Poi {
     virtual ~Term() = 0;
     virtual std::size_t emit_ir(
       std::shared_ptr<const Poi::Term> term,
-      BasicBlock &current_block,
+      IrBlock &current_block,
       std::size_t destination, // Don't touch any registers under this one.
       bool tail_position,
       const std::unordered_map<std::size_t, VariableInfo> &environment
@@ -128,7 +128,7 @@ namespace Poi {
     std::string show(const StringPool &pool) const override;
     std::size_t emit_ir(
       std::shared_ptr<const Poi::Term> term,
-      BasicBlock &current_block,
+      IrBlock &current_block,
       std::size_t destination,
       bool tail_position,
       const std::unordered_map<std::size_t, VariableInfo> &environment
@@ -152,7 +152,7 @@ namespace Poi {
     std::string show(const StringPool &pool) const override;
     std::size_t emit_ir(
       std::shared_ptr<const Poi::Term> term,
-      BasicBlock &current_block,
+      IrBlock &current_block,
       std::size_t destination,
       bool tail_position,
       const std::unordered_map<std::size_t, VariableInfo> &environment
@@ -176,7 +176,7 @@ namespace Poi {
     std::string show(const StringPool &pool) const override;
     std::size_t emit_ir(
       std::shared_ptr<const Poi::Term> term,
-      BasicBlock &current_block,
+      IrBlock &current_block,
       std::size_t destination,
       bool tail_position,
       const std::unordered_map<std::size_t, VariableInfo> &environment
@@ -202,7 +202,7 @@ namespace Poi {
     std::string show(const StringPool &pool) const override;
     std::size_t emit_ir(
       std::shared_ptr<const Poi::Term> term,
-      BasicBlock &current_block,
+      IrBlock &current_block,
       std::size_t destination,
       bool tail_position,
       const std::unordered_map<std::size_t, VariableInfo> &environment
@@ -236,7 +236,7 @@ namespace Poi {
     std::string show(const StringPool &pool) const override;
     std::size_t emit_ir(
       std::shared_ptr<const Poi::Term> term,
-      BasicBlock &current_block,
+      IrBlock &current_block,
       std::size_t destination,
       bool tail_position,
       const std::unordered_map<std::size_t, VariableInfo> &environment
@@ -263,7 +263,7 @@ namespace Poi {
     std::string show(const StringPool &pool) const override;
     std::size_t emit_ir(
       std::shared_ptr<const Poi::Term> term,
-      BasicBlock &current_block,
+      IrBlock &current_block,
       std::size_t destination,
       bool tail_position,
       const std::unordered_map<std::size_t, VariableInfo> &environment
@@ -292,7 +292,7 @@ namespace Poi {
     std::string show(const StringPool &pool) const override;
     std::size_t emit_ir(
       std::shared_ptr<const Poi::Term> term,
-      BasicBlock &current_block,
+      IrBlock &current_block,
       std::size_t destination,
       bool tail_position,
       const std::unordered_map<std::size_t, VariableInfo> &environment
@@ -320,7 +320,7 @@ namespace Poi {
     std::string show(const StringPool &pool) const override;
     std::size_t emit_ir(
       std::shared_ptr<const Poi::Term> term,
-      BasicBlock &current_block,
+      IrBlock &current_block,
       std::size_t destination,
       bool tail_position,
       const std::unordered_map<std::size_t, VariableInfo> &environment

--- a/include/bytecode.h
+++ b/include/bytecode.h
@@ -7,6 +7,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <poi/ast.h>
 #include <poi/string_pool.h>
 #include <string>
 #include <type_traits>
@@ -114,6 +115,17 @@ namespace Poi {
     std::is_pod<Bytecode>::value,
     "Poi::Bytecode must be a POD type."
   );
+
+  class BytecodeBlock {
+  public:
+    std::vector<Bytecode> bytecode;
+    std::vector<std::shared_ptr<const Node>> nodes;
+
+    void push(Bytecode &bc, std::shared_ptr<const Node> node);
+    void append(BytecodeBlock &block);
+    std::size_t size() const;
+    std::string show() const;
+  };
 }
 
 #endif

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -14,14 +14,10 @@
 
 namespace Poi {
   // Compile an AST into IR.
-  std::shared_ptr<BasicBlock> compile_ast_to_ir(
-    std::shared_ptr<const Term> term
-  );
+  std::shared_ptr<IrBlock> compile_ast_to_ir(std::shared_ptr<const Term> term);
 
   // Compile IR into BC.
-  std::shared_ptr<std::vector<Bytecode>> compile_ir_to_bc(
-    const BasicBlock &basic_block
-  );
+  std::shared_ptr<BytecodeBlock> compile_ir_to_bc(const IrBlock &ir_block);
 }
 
 #endif

--- a/include/interpreter.h
+++ b/include/interpreter.h
@@ -7,14 +7,16 @@
 
 #include <cstddef>
 #include <poi/bytecode.h>
+#include <poi/string_pool.h>
 #include <poi/value.h>
 #include <vector>
 
 namespace Poi {
   // Interpret a BC program.
   Value * interpret(
-    Bytecode * program,
-    std::size_t start_stack_size // Stack locations (not bytes)
+    std::size_t start_stack_size, // Stack locations (not bytes)
+    const BytecodeBlock &block,
+    const Poi::StringPool &pool
   );
 }
 

--- a/include/ir.h
+++ b/include/ir.h
@@ -13,27 +13,6 @@
 #include <vector>
 
 namespace Poi {
-  class IrInstruction;
-
-  class BasicBlock {
-  public:
-    explicit BasicBlock();
-    std::shared_ptr<
-      std::vector<std::shared_ptr<const IrInstruction>>
-    > get_instructions();
-    std::uint16_t frame_size() const;
-    void emit_bytecode(
-      std::vector<Bytecode> &archive,
-      std::vector<Bytecode> &current
-    ) const;
-    std::string show() const;
-
-  private:
-    std::shared_ptr<
-      std::vector<std::shared_ptr<const IrInstruction>>
-    > instructions;
-  };
-
   class IrInstruction {
   public:
     const std::shared_ptr<const Node> node;
@@ -43,8 +22,8 @@ namespace Poi {
     virtual bool terminates_block() const = 0;
     virtual std::uint16_t max_register() const = 0;
     virtual void emit_bytecode(
-      std::vector<Bytecode> &archive,
-      std::vector<Bytecode> &current
+      BytecodeBlock &archive,
+      BytecodeBlock &current
     ) const = 0; // Returns the number of registers used so far
     virtual std::string show() const = 0;
   };
@@ -60,8 +39,8 @@ namespace Poi {
     bool terminates_block() const override;
     std::uint16_t max_register() const override;
     void emit_bytecode(
-      std::vector<Bytecode> &archive,
-      std::vector<Bytecode> &current
+      BytecodeBlock &archive,
+      BytecodeBlock &current
     ) const override;
     std::string show() const override;
   };
@@ -81,8 +60,8 @@ namespace Poi {
     bool terminates_block() const override;
     std::uint16_t max_register() const override;
     void emit_bytecode(
-      std::vector<Bytecode> &archive,
-      std::vector<Bytecode> &current
+      BytecodeBlock &archive,
+      BytecodeBlock &current
     ) const override;
     std::string show() const override;
   };
@@ -100,8 +79,8 @@ namespace Poi {
     bool terminates_block() const override;
     std::uint16_t max_register() const override;
     void emit_bytecode(
-      std::vector<Bytecode> &archive,
-      std::vector<Bytecode> &current
+      BytecodeBlock &archive,
+      BytecodeBlock &current
     ) const override;
     std::string show() const override;
   };
@@ -119,8 +98,8 @@ namespace Poi {
     bool terminates_block() const override;
     std::uint16_t max_register() const override;
     void emit_bytecode(
-      std::vector<Bytecode> &archive,
-      std::vector<Bytecode> &current
+      BytecodeBlock &archive,
+      BytecodeBlock &current
     ) const override;
     std::string show() const override;
   };
@@ -128,20 +107,20 @@ namespace Poi {
   class IrCreateFunction : public IrInstruction {
   public:
     const std::uint16_t destination;
-    const std::shared_ptr<const BasicBlock> body;
+    const std::shared_ptr<const IrBlock> body;
     const std::shared_ptr<std::vector<std::uint16_t>> captures;
 
     explicit IrCreateFunction(
       std::uint16_t destination,
-      std::shared_ptr<const BasicBlock> body,
+      std::shared_ptr<const IrBlock> body,
       std::shared_ptr<std::vector<std::uint16_t>> captures,
       const std::shared_ptr<const Node> node
     );
     bool terminates_block() const override;
     std::uint16_t max_register() const override;
     void emit_bytecode(
-      std::vector<Bytecode> &archive,
-      std::vector<Bytecode> &current
+      BytecodeBlock &archive,
+      BytecodeBlock &current
     ) const override;
     std::string show() const override;
   };
@@ -159,8 +138,8 @@ namespace Poi {
     bool terminates_block() const override;
     std::uint16_t max_register() const override;
     void emit_bytecode(
-      std::vector<Bytecode> &archive,
-      std::vector<Bytecode> &current
+      BytecodeBlock &archive,
+      BytecodeBlock &current
     ) const override;
     std::string show() const override;
   };
@@ -178,8 +157,8 @@ namespace Poi {
     bool terminates_block() const override;
     std::uint16_t max_register() const override;
     void emit_bytecode(
-      std::vector<Bytecode> &archive,
-      std::vector<Bytecode> &current
+      BytecodeBlock &archive,
+      BytecodeBlock &current
     ) const override;
     std::string show() const override;
   };
@@ -195,8 +174,8 @@ namespace Poi {
     bool terminates_block() const override;
     std::uint16_t max_register() const override;
     void emit_bytecode(
-      std::vector<Bytecode> &archive,
-      std::vector<Bytecode> &current
+      BytecodeBlock &archive,
+      BytecodeBlock &current
     ) const override;
     std::string show() const override;
   };
@@ -212,10 +191,29 @@ namespace Poi {
     bool terminates_block() const override;
     std::uint16_t max_register() const override;
     void emit_bytecode(
-      std::vector<Bytecode> &archive,
-      std::vector<Bytecode> &current
+      BytecodeBlock &archive,
+      BytecodeBlock &current
     ) const override;
     std::string show() const override;
+  };
+
+  class IrBlock {
+  public:
+    explicit IrBlock();
+    std::shared_ptr<
+      std::vector<std::shared_ptr<const IrInstruction>>
+    > get_instructions();
+    std::uint16_t frame_size() const;
+    void emit_bytecode(
+      BytecodeBlock &archive,
+      BytecodeBlock &current
+    ) const;
+    std::string show() const;
+
+  private:
+    std::shared_ptr<
+      std::vector<std::shared_ptr<const IrInstruction>>
+    > instructions;
   };
 }
 

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -165,7 +165,7 @@ std::string Poi::Variable::show(const Poi::StringPool &pool) const {
 
 std::size_t Poi::Variable::emit_ir(
   std::shared_ptr<const Poi::Term> term,
-  BasicBlock &current_block,
+  IrBlock &current_block,
   std::size_t destination,
   bool tail_position,
   const std::unordered_map<std::size_t, VariableInfo> &environment
@@ -218,7 +218,7 @@ std::string Poi::Function::show(const Poi::StringPool &pool) const {
 
 std::size_t Poi::Function::emit_ir(
   std::shared_ptr<const Poi::Term> term,
-  BasicBlock &current_block,
+  IrBlock &current_block,
   std::size_t destination,
   bool tail_position,
   const std::unordered_map<std::size_t, VariableInfo> &environment
@@ -244,7 +244,7 @@ std::size_t Poi::Function::emit_ir(
     index++;
   }
 
-  auto body_block = std::make_shared<BasicBlock>();
+  auto body_block = std::make_shared<IrBlock>();
   body->emit_ir(
     body,
     *body_block,
@@ -300,7 +300,7 @@ std::string Poi::Application::show(const Poi::StringPool &pool) const {
 
 std::size_t Poi::Application::emit_ir(
   std::shared_ptr<const Poi::Term> term,
-  BasicBlock &current_block,
+  IrBlock &current_block,
   std::size_t destination,
   bool tail_position,
   const std::unordered_map<std::size_t, VariableInfo> &environment
@@ -378,7 +378,7 @@ std::string Poi::Binding::show(const Poi::StringPool &pool) const {
 
 std::size_t Poi::Binding::emit_ir(
   std::shared_ptr<const Poi::Term> term,
-  BasicBlock &current_block,
+  IrBlock &current_block,
   std::size_t destination,
   bool tail_position,
   const std::unordered_map<std::size_t, VariableInfo> &environment
@@ -499,7 +499,7 @@ std::string Poi::DataType::show(const Poi::StringPool &pool) const {
 
 std::size_t Poi::DataType::emit_ir(
   std::shared_ptr<const Poi::Term> term,
-  BasicBlock &current_block,
+  IrBlock &current_block,
   std::size_t destination,
   bool tail_position,
   const std::unordered_map<std::size_t, VariableInfo> &environment
@@ -539,7 +539,7 @@ std::string Poi::Data::show(const Poi::StringPool &pool) const {
 
 std::size_t Poi::Data::emit_ir(
   std::shared_ptr<const Poi::Term> term,
-  BasicBlock &current_block,
+  IrBlock &current_block,
   std::size_t destination,
   bool tail_position,
   const std::unordered_map<std::size_t, VariableInfo> &environment
@@ -574,7 +574,7 @@ std::string Poi::Member::show(const Poi::StringPool &pool) const {
 
 std::size_t Poi::Member::emit_ir(
   std::shared_ptr<const Poi::Term> term,
-  BasicBlock &current_block,
+  IrBlock &current_block,
   std::size_t destination,
   bool tail_position,
   const std::unordered_map<std::size_t, VariableInfo> &environment
@@ -621,7 +621,7 @@ std::string Poi::Match::show(const Poi::StringPool &pool) const {
 
 std::size_t Poi::Match::emit_ir(
   std::shared_ptr<const Poi::Term> term,
-  BasicBlock &current_block,
+  IrBlock &current_block,
   std::size_t destination,
   bool tail_position,
   const std::unordered_map<std::size_t, VariableInfo> &environment

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -115,3 +115,36 @@ std::string Poi::Bytecode::show() const {
   }
   return result;
 }
+
+void Poi::BytecodeBlock::push(
+  Poi::Bytecode &bc,
+  std::shared_ptr<const Poi::Node> node
+) {
+  bytecode.push_back(bc);
+  nodes.push_back(node);
+}
+
+void Poi::BytecodeBlock::append(Poi::BytecodeBlock &block) {
+  bytecode.insert(
+    bytecode.end(),
+    block.bytecode.begin(),
+    block.bytecode.end()
+  );
+  nodes.insert(
+    nodes.end(),
+    block.nodes.begin(),
+    block.nodes.end()
+  );
+}
+
+std::size_t Poi::BytecodeBlock::size() const {
+  return bytecode.size();
+}
+
+std::string Poi::BytecodeBlock::show() const {
+  std::string result;
+  for (std::size_t i = 0; i < bytecode.size(); ++i) {
+    result += std::to_string(i) + " " + bytecode[i].show() + "\n";
+  }
+  return result;
+}

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -5,10 +5,10 @@
 #include <poi/ir.h>
 #include <vector>
 
-std::shared_ptr<Poi::BasicBlock> Poi::compile_ast_to_ir(
+std::shared_ptr<Poi::IrBlock> Poi::compile_ast_to_ir(
   std::shared_ptr<const Poi::Term> term
 ) {
-  auto block = std::make_shared<BasicBlock>();
+  auto block = std::make_shared<IrBlock>();
   std::unordered_map<std::size_t, VariableInfo> environment;
   term->emit_ir(term, *block, 0, false, environment);
   block->get_instructions()->push_back(
@@ -17,16 +17,16 @@ std::shared_ptr<Poi::BasicBlock> Poi::compile_ast_to_ir(
   return block;
 }
 
-std::shared_ptr<std::vector<Poi::Bytecode>> Poi::compile_ir_to_bc(
-  const Poi::BasicBlock &basic_block
+std::shared_ptr<Poi::BytecodeBlock> Poi::compile_ir_to_bc(
+  const Poi::IrBlock &ir_block
 ) {
-  std::vector<Bytecode> program;
-  auto bytecode = std::make_shared<std::vector<Bytecode>>();
-  basic_block.emit_bytecode(program, *bytecode);
-  std::ptrdiff_t offset = bytecode->size();
-  bytecode->insert(bytecode->end(), program.begin(), program.end());
-  for (auto &bc : *bytecode) {
+  BytecodeBlock archive;
+  auto current = std::make_shared<BytecodeBlock>();
+  ir_block.emit_bytecode(archive, *current);
+  std::ptrdiff_t offset = current->size();
+  current->append(archive);
+  for (auto &bc : current->bytecode) {
     bc.relocate(offset);
   }
-  return bytecode;
+  return current;
 }


### PR DESCRIPTION
Add stack traces. Note that tail recursion optimization means many stack frames are omitted in general.

Given this example:

```
f = x -> (a -> a) (a = a, a)
g = x -> (a -> a) (f (a -> a))
h = x -> (a -> a) (g (a -> a))
h (a -> a)
```

We get the following error:

```
Error: Recursive reference evaluated before the knot has been tied.

Stack trace:
  example.poi @ 1:24
  example.poi @ 2:19 - 2:30
  example.poi @ 3:19 - 3:30
  example.poi @ 4:1 - 4:10

Location: example.poi @ 1:24

f = x -> (a -> a) (a = a, a)
                       ^
```

**Status:** Ready

**Fixes:** N/A
