### PR TITLE
Rename some instructions

### DIFF
--- a/include/bytecode.h
+++ b/include/bytecode.h
@@ -15,26 +15,26 @@
 namespace Poi {
   enum class BytecodeType {
     BEGIN_FIXPOINT,
-    CALL_NON_TAIL,
-    CALL_TAIL,
-    COPY,
+    CALL,
     CREATE_FUNCTION,
     DEREF_FIXPOINT,
     END_FIXPOINT,
     EXIT,
-    RETURN
+    MOVE,
+    RETURN,
+    TAIL_CALL
   };
 
   const char * const BytecodeTypeName[] = {
     "BEGIN_FIXPOINT",
-    "CALL_NON_TAIL",
-    "CALL_TAIL",
-    "COPY",
+    "CALL",
     "CREATE_FUNCTION",
     "DEREF_FIXPOINT",
     "END_FIXPOINT",
     "EXIT",
-    "RETURN"
+    "MOVE",
+    "RETURN",
+    "TAIL_CALL"
   };
 
   class BeginFixpointArgs {
@@ -42,23 +42,11 @@ namespace Poi {
     std::uint16_t destination;
   };
 
-  class CallNonTailArgs {
+  class CallArgs {
   public:
     std::uint16_t destination;
     std::uint16_t function;
     std::uint16_t argument;
-  };
-
-  class CallTailArgs {
-  public:
-    std::uint16_t function;
-    std::uint16_t argument;
-  };
-
-  class CopyArgs {
-  public:
-    std::uint16_t destination;
-    std::uint16_t source;
   };
 
   class CreateFunctionArgs {
@@ -87,9 +75,21 @@ namespace Poi {
     std::uint16_t value;
   };
 
+  class MoveArgs {
+  public:
+    std::uint16_t destination;
+    std::uint16_t source;
+  };
+
   class ReturnArgs {
   public:
     std::uint16_t value;
+  };
+
+  class TailCallArgs {
+  public:
+    std::uint16_t function;
+    std::uint16_t argument;
   };
 
   class Bytecode {
@@ -97,14 +97,14 @@ namespace Poi {
     BytecodeType type;
     union {
       BeginFixpointArgs begin_fixpoint_args;
-      CallNonTailArgs call_non_tail_args;
-      CallTailArgs call_tail_args;
-      CopyArgs copy_args;
+      CallArgs call_non_tail_args;
       CreateFunctionArgs create_function_args;
       DerefFixpointArgs deref_fixpoint_args;
       EndFixpointArgs end_fixpoint_args;
       ExitArgs exit_args;
+      MoveArgs move_args;
       ReturnArgs return_args;
+      TailCallArgs call_tail_args;
     };
 
     void relocate(std::ptrdiff_t offset); // Shift instruction pointers

--- a/include/ir.h
+++ b/include/ir.h
@@ -45,54 +45,16 @@ namespace Poi {
     std::string show() const override;
   };
 
-  class IrCallNonTail : public IrInstruction {
+  class IrCall : public IrInstruction {
   public:
     const std::uint16_t destination;
     const std::uint16_t function;
     const std::uint16_t argument;
 
-    explicit IrCallNonTail(
+    explicit IrCall(
       std::uint16_t destination,
       std::uint16_t function,
       std::uint16_t argument,
-      const std::shared_ptr<const Node> node
-    );
-    bool terminates_block() const override;
-    std::uint16_t max_register() const override;
-    void emit_bytecode(
-      BytecodeBlock &archive,
-      BytecodeBlock &current
-    ) const override;
-    std::string show() const override;
-  };
-
-  class IrCallTail : public IrInstruction {
-  public:
-    const std::uint16_t function;
-    const std::uint16_t argument;
-
-    explicit IrCallTail(
-      std::uint16_t function,
-      std::uint16_t argument,
-      const std::shared_ptr<const Node> node
-    );
-    bool terminates_block() const override;
-    std::uint16_t max_register() const override;
-    void emit_bytecode(
-      BytecodeBlock &archive,
-      BytecodeBlock &current
-    ) const override;
-    std::string show() const override;
-  };
-
-  class IrCopy : public IrInstruction {
-  public:
-    const std::uint16_t destination;
-    const std::uint16_t source;
-
-    explicit IrCopy(
-      std::uint16_t destination,
-      std::uint16_t source,
       const std::shared_ptr<const Node> node
     );
     bool terminates_block() const override;
@@ -180,12 +142,50 @@ namespace Poi {
     std::string show() const override;
   };
 
+  class IrMove : public IrInstruction {
+  public:
+    const std::uint16_t destination;
+    const std::uint16_t source;
+
+    explicit IrMove(
+      std::uint16_t destination,
+      std::uint16_t source,
+      const std::shared_ptr<const Node> node
+    );
+    bool terminates_block() const override;
+    std::uint16_t max_register() const override;
+    void emit_bytecode(
+      BytecodeBlock &archive,
+      BytecodeBlock &current
+    ) const override;
+    std::string show() const override;
+  };
+
   class IrReturn : public IrInstruction {
   public:
     const std::uint16_t value;
 
     explicit IrReturn(
       std::uint16_t value,
+      const std::shared_ptr<const Node> node
+    );
+    bool terminates_block() const override;
+    std::uint16_t max_register() const override;
+    void emit_bytecode(
+      BytecodeBlock &archive,
+      BytecodeBlock &current
+    ) const override;
+    std::string show() const override;
+  };
+
+  class IrTailCall : public IrInstruction {
+  public:
+    const std::uint16_t function;
+    const std::uint16_t argument;
+
+    explicit IrTailCall(
+      std::uint16_t function,
+      std::uint16_t argument,
       const std::shared_ptr<const Node> node
     );
     bool terminates_block() const override;

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -181,7 +181,7 @@ std::size_t Poi::Variable::emit_ir(
     );
   } else {
     current_block.get_instructions()->push_back(
-      std::make_shared<IrCopy>(
+      std::make_shared<IrMove>(
         destination,
         variable_iter->second.stack_location,
         std::static_pointer_cast<const Node>(term)
@@ -323,7 +323,7 @@ std::size_t Poi::Application::emit_ir(
 
   if (tail_position) {
     current_block.get_instructions()->push_back(
-      std::make_shared<IrCallTail>(
+      std::make_shared<IrTailCall>(
         destination + 1,
         destination + 1 + function_footprint,
         std::static_pointer_cast<const Node>(term)
@@ -331,7 +331,7 @@ std::size_t Poi::Application::emit_ir(
     );
   } else {
     current_block.get_instructions()->push_back(
-      std::make_shared<IrCallNonTail>(
+      std::make_shared<IrCall>(
         destination,
         destination + 1,
         destination + 1 + function_footprint,
@@ -438,7 +438,7 @@ std::size_t Poi::Binding::emit_ir(
 
   if (!current_block.get_instructions()->back()->terminates_block()) {
     current_block.get_instructions()->push_back(
-      std::make_shared<IrCopy>(
+      std::make_shared<IrMove>(
         destination,
         destination + 2 + definition_footprint,
         std::static_pointer_cast<const Node>(term)

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -11,13 +11,7 @@ void Poi::Bytecode::relocate(std::ptrdiff_t offset) {
     case BytecodeType::BEGIN_FIXPOINT: {
       break;
     }
-    case BytecodeType::CALL_NON_TAIL: {
-      break;
-    }
-    case BytecodeType::CALL_TAIL: {
-      break;
-    }
-    case BytecodeType::COPY: {
+    case BytecodeType::CALL: {
       break;
     }
     case BytecodeType::CREATE_FUNCTION: {
@@ -33,7 +27,13 @@ void Poi::Bytecode::relocate(std::ptrdiff_t offset) {
     case BytecodeType::EXIT: {
       break;
     }
+    case BytecodeType::MOVE: {
+      break;
+    }
     case BytecodeType::RETURN: {
+      break;
+    }
+    case BytecodeType::TAIL_CALL: {
       break;
     }
     default: {
@@ -53,23 +53,11 @@ std::string Poi::Bytecode::show() const {
         " destination=" + std::to_string(begin_fixpoint_args.destination);
       break;
     }
-    case BytecodeType::CALL_NON_TAIL: {
+    case BytecodeType::CALL: {
       result +=
         " destination=" + std::to_string(call_non_tail_args.destination) +
         " function=" + std::to_string(call_non_tail_args.function) +
         " argument=" + std::to_string(call_non_tail_args.argument);
-      break;
-    }
-    case BytecodeType::CALL_TAIL: {
-      result +=
-        " function=" + std::to_string(call_tail_args.function) +
-        " argument=" + std::to_string(call_tail_args.argument);
-      break;
-    }
-    case BytecodeType::COPY: {
-      result +=
-        " destination=" + std::to_string(copy_args.destination) +
-        " source=" + std::to_string(copy_args.source);
       break;
     }
     case BytecodeType::CREATE_FUNCTION: {
@@ -104,9 +92,21 @@ std::string Poi::Bytecode::show() const {
         " value=" + std::to_string(exit_args.value);
       break;
     }
+    case BytecodeType::MOVE: {
+      result +=
+        " destination=" + std::to_string(move_args.destination) +
+        " source=" + std::to_string(move_args.source);
+      break;
+    }
     case BytecodeType::RETURN: {
       result +=
         " value=" + std::to_string(return_args.value);
+      break;
+    }
+    case BytecodeType::TAIL_CALL: {
+      result +=
+        " function=" + std::to_string(call_tail_args.function) +
+        " argument=" + std::to_string(call_tail_args.argument);
       break;
     }
     default: {

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -47,10 +47,10 @@ std::string Poi::IrBeginFixpoint::show() const {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-// IrCallNonTail                                                             //
+// IrCall                                                                    //
 ///////////////////////////////////////////////////////////////////////////////
 
-Poi::IrCallNonTail::IrCallNonTail(
+Poi::IrCall::IrCall(
   std::uint16_t destination,
   std::uint16_t function,
   std::uint16_t argument,
@@ -62,106 +62,31 @@ Poi::IrCallNonTail::IrCallNonTail(
   argument(argument) {
 }
 
-bool Poi::IrCallNonTail::terminates_block() const {
+bool Poi::IrCall::terminates_block() const {
   return false;
 }
 
-std::uint16_t Poi::IrCallNonTail::max_register() const {
+std::uint16_t Poi::IrCall::max_register() const {
   return std::max(destination, std::max(function, argument));
 }
 
-void Poi::IrCallNonTail::emit_bytecode(
+void Poi::IrCall::emit_bytecode(
   Poi::BytecodeBlock &archive,
   Poi::BytecodeBlock &current
 ) const {
   Bytecode bc;
-  bc.type = BytecodeType::CALL_NON_TAIL;
+  bc.type = BytecodeType::CALL;
   bc.call_non_tail_args.destination = destination;
   bc.call_non_tail_args.function = function;
   bc.call_non_tail_args.argument = argument;
   current.push(bc, node);
 }
 
-std::string Poi::IrCallNonTail::show() const {
-  return std::string("CALL_NON_TAIL") +
+std::string Poi::IrCall::show() const {
+  return std::string("CALL") +
     " destination=" + std::to_string(destination) +
     " function=" + std::to_string(function) +
     " argument=" + std::to_string(argument);
-}
-
-///////////////////////////////////////////////////////////////////////////////
-// IrCallTail                                                                //
-///////////////////////////////////////////////////////////////////////////////
-
-Poi::IrCallTail::IrCallTail(
-  std::uint16_t function,
-  std::uint16_t argument,
-  const std::shared_ptr<const Node> node
-) : Poi::IrInstruction(node), function(function), argument(argument) {
-}
-
-bool Poi::IrCallTail::terminates_block() const {
-  return true;
-}
-
-std::uint16_t Poi::IrCallTail::max_register() const {
-  return std::max(function, argument);
-}
-
-void Poi::IrCallTail::emit_bytecode(
-  Poi::BytecodeBlock &archive,
-  Poi::BytecodeBlock &current
-) const {
-  Bytecode bc;
-  bc.type = BytecodeType::CALL_TAIL;
-  bc.call_tail_args.function = function;
-  bc.call_tail_args.argument = argument;
-  current.push(bc, node);
-}
-
-std::string Poi::IrCallTail::show() const {
-  return std::string("CALL_TAIL") +
-    " function=" + std::to_string(function) +
-    " argument=" + std::to_string(argument);
-}
-
-///////////////////////////////////////////////////////////////////////////////
-// IrCopy                                                                    //
-///////////////////////////////////////////////////////////////////////////////
-
-Poi::IrCopy::IrCopy(
-  std::uint16_t destination,
-  std::uint16_t source,
-  const std::shared_ptr<const Node> node
-) :
-  Poi::IrInstruction(node),
-  destination(destination),
-  source(source) {
-}
-
-bool Poi::IrCopy::terminates_block() const {
-  return false;
-}
-
-std::uint16_t Poi::IrCopy::max_register() const {
-  return std::max(destination, source);
-}
-
-void Poi::IrCopy::emit_bytecode(
-  Poi::BytecodeBlock &archive,
-  Poi::BytecodeBlock &current
-) const {
-  Bytecode bc;
-  bc.type = BytecodeType::COPY;
-  bc.copy_args.destination = destination;
-  bc.copy_args.source = source;
-  current.push(bc, node);
-}
-
-std::string Poi::IrCopy::show() const {
-  return std::string("COPY") +
-    " destination=" + std::to_string(destination) +
-    " source=" + std::to_string(source);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -342,6 +267,45 @@ std::string Poi::IrExit::show() const {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// IrMove                                                                    //
+///////////////////////////////////////////////////////////////////////////////
+
+Poi::IrMove::IrMove(
+  std::uint16_t destination,
+  std::uint16_t source,
+  const std::shared_ptr<const Node> node
+) :
+  Poi::IrInstruction(node),
+  destination(destination),
+  source(source) {
+}
+
+bool Poi::IrMove::terminates_block() const {
+  return false;
+}
+
+std::uint16_t Poi::IrMove::max_register() const {
+  return std::max(destination, source);
+}
+
+void Poi::IrMove::emit_bytecode(
+  Poi::BytecodeBlock &archive,
+  Poi::BytecodeBlock &current
+) const {
+  Bytecode bc;
+  bc.type = BytecodeType::MOVE;
+  bc.move_args.destination = destination;
+  bc.move_args.source = source;
+  current.push(bc, node);
+}
+
+std::string Poi::IrMove::show() const {
+  return std::string("MOVE") +
+    " destination=" + std::to_string(destination) +
+    " source=" + std::to_string(source);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // IrReturn                                                                  //
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -418,4 +382,40 @@ std::shared_ptr<
   std::vector<std::shared_ptr<const Poi::IrInstruction>>
 > Poi::IrBlock::get_instructions() {
   return instructions;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// IrTailCall                                                                //
+///////////////////////////////////////////////////////////////////////////////
+
+Poi::IrTailCall::IrTailCall(
+  std::uint16_t function,
+  std::uint16_t argument,
+  const std::shared_ptr<const Node> node
+) : Poi::IrInstruction(node), function(function), argument(argument) {
+}
+
+bool Poi::IrTailCall::terminates_block() const {
+  return true;
+}
+
+std::uint16_t Poi::IrTailCall::max_register() const {
+  return std::max(function, argument);
+}
+
+void Poi::IrTailCall::emit_bytecode(
+  Poi::BytecodeBlock &archive,
+  Poi::BytecodeBlock &current
+) const {
+  Bytecode bc;
+  bc.type = BytecodeType::TAIL_CALL;
+  bc.call_tail_args.function = function;
+  bc.call_tail_args.argument = argument;
+  current.push(bc, node);
+}
+
+std::string Poi::IrTailCall::show() const {
+  return std::string("TAIL_CALL") +
+    " function=" + std::to_string(function) +
+    " argument=" + std::to_string(argument);
 }


### PR DESCRIPTION
Rename some instructions:

- `CALL_NON_TAIL` -> `CALL`
- `CALL_TAIL` -> `TAIL_CALL`
- `COPY` -> `MOVE`

**Status:** Ready

**Fixes:** N/A
