### PR TITLE
Implement a register allocator

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -21,6 +21,7 @@ enum class CliAction {
   EMIT_TOKENS,
   EMIT_AST,
   EMIT_IR,
+  EMIT_OPTIMIZED_IR,
   EMIT_BC,
   RUN
 };
@@ -49,6 +50,7 @@ int main(int argc, char * argv[]) {
       "  poi --emit-tokens source\n"
       "  poi --emit-ast source\n"
       "  poi --emit-ir source\n"
+      "  poi --emit-optimized-ir source\n"
       "  poi --emit-bc source\n"
       "  poi --run source\n";
     return 0;
@@ -80,6 +82,8 @@ int main(int argc, char * argv[]) {
       cli_action = CliAction::EMIT_AST;
     } else if (std::string(argv[1]) == "--emit-ir") {
       cli_action = CliAction::EMIT_IR;
+    } else if (std::string(argv[1]) == "--emit-optimized-ir") {
+      cli_action = CliAction::EMIT_OPTIMIZED_IR;
     } else if (std::string(argv[1]) == "--emit-bc") {
       cli_action = CliAction::EMIT_BC;
     } else if (std::string(argv[1]) == "--run") {
@@ -135,6 +139,10 @@ int main(int argc, char * argv[]) {
 
     // Optimize the IR.
     auto optimized_ir_block = optimize(ir_block);
+    if (cli_action == CliAction::EMIT_OPTIMIZED_IR) {
+      std::cout << optimized_ir_block->show();
+      return 0;
+    }
 
     // Compile the IR into BC.
     auto bytecode_block = compile_ir_to_bc(*optimized_ir_block);

--- a/include/bytecode.h
+++ b/include/bytecode.h
@@ -20,7 +20,6 @@ namespace Poi {
     DEREF_FIXPOINT,
     END_FIXPOINT,
     EXIT,
-    MOVE,
     RETURN,
     TAIL_CALL
   };
@@ -32,7 +31,6 @@ namespace Poi {
     "DEREF_FIXPOINT",
     "END_FIXPOINT",
     "EXIT",
-    "MOVE",
     "RETURN",
     "TAIL_CALL"
   };
@@ -75,12 +73,6 @@ namespace Poi {
     std::uint16_t value;
   };
 
-  class MoveArgs {
-  public:
-    std::uint16_t destination;
-    std::uint16_t source;
-  };
-
   class ReturnArgs {
   public:
     std::uint16_t value;
@@ -102,7 +94,6 @@ namespace Poi {
       DerefFixpointArgs deref_fixpoint_args;
       EndFixpointArgs end_fixpoint_args;
       ExitArgs exit_args;
-      MoveArgs move_args;
       ReturnArgs return_args;
       TailCallArgs call_tail_args;
     };

--- a/include/ir.h
+++ b/include/ir.h
@@ -19,7 +19,6 @@ namespace Poi {
 
     explicit IrInstruction(const std::shared_ptr<const Node> node);
     virtual ~IrInstruction() = 0;
-    virtual bool terminates_block() const = 0;
     virtual std::uint16_t max_register() const = 0;
     virtual void emit_bytecode(
       BytecodeBlock &archive,
@@ -36,7 +35,6 @@ namespace Poi {
       std::uint16_t destination,
       const std::shared_ptr<const Node> node
     );
-    bool terminates_block() const override;
     std::uint16_t max_register() const override;
     void emit_bytecode(
       BytecodeBlock &archive,
@@ -57,7 +55,6 @@ namespace Poi {
       std::uint16_t argument,
       const std::shared_ptr<const Node> node
     );
-    bool terminates_block() const override;
     std::uint16_t max_register() const override;
     void emit_bytecode(
       BytecodeBlock &archive,
@@ -78,7 +75,6 @@ namespace Poi {
       std::shared_ptr<std::vector<std::uint16_t>> captures,
       const std::shared_ptr<const Node> node
     );
-    bool terminates_block() const override;
     std::uint16_t max_register() const override;
     void emit_bytecode(
       BytecodeBlock &archive,
@@ -97,7 +93,6 @@ namespace Poi {
       std::uint16_t fixpoint,
       const std::shared_ptr<const Node> node
     );
-    bool terminates_block() const override;
     std::uint16_t max_register() const override;
     void emit_bytecode(
       BytecodeBlock &archive,
@@ -116,7 +111,6 @@ namespace Poi {
       std::uint16_t target,
       const std::shared_ptr<const Node> node
     );
-    bool terminates_block() const override;
     std::uint16_t max_register() const override;
     void emit_bytecode(
       BytecodeBlock &archive,
@@ -133,7 +127,6 @@ namespace Poi {
       std::uint16_t value,
       const std::shared_ptr<const Node> node
     );
-    bool terminates_block() const override;
     std::uint16_t max_register() const override;
     void emit_bytecode(
       BytecodeBlock &archive,
@@ -152,7 +145,6 @@ namespace Poi {
       std::uint16_t source,
       const std::shared_ptr<const Node> node
     );
-    bool terminates_block() const override;
     std::uint16_t max_register() const override;
     void emit_bytecode(
       BytecodeBlock &archive,
@@ -169,7 +161,6 @@ namespace Poi {
       std::uint16_t value,
       const std::shared_ptr<const Node> node
     );
-    bool terminates_block() const override;
     std::uint16_t max_register() const override;
     void emit_bytecode(
       BytecodeBlock &archive,
@@ -188,7 +179,6 @@ namespace Poi {
       std::uint16_t argument,
       const std::shared_ptr<const Node> node
     );
-    bool terminates_block() const override;
     std::uint16_t max_register() const override;
     void emit_bytecode(
       BytecodeBlock &archive,
@@ -200,9 +190,6 @@ namespace Poi {
   class IrBlock {
   public:
     explicit IrBlock();
-    std::shared_ptr<
-      std::vector<std::shared_ptr<const IrInstruction>>
-    > get_instructions();
     std::uint16_t frame_size() const;
     void emit_bytecode(
       BytecodeBlock &archive,
@@ -210,7 +197,6 @@ namespace Poi {
     ) const;
     std::string show() const;
 
-  private:
     std::shared_ptr<
       std::vector<std::shared_ptr<const IrInstruction>>
     > instructions;

--- a/include/optimizer.h
+++ b/include/optimizer.h
@@ -10,7 +10,9 @@
 
 namespace Poi {
   // Optimize a block of IR.
-  std::shared_ptr<IrBlock> optimize(std::shared_ptr<IrBlock> block);
+  const std::shared_ptr<const IrBlock> optimize(
+    const std::shared_ptr<const IrBlock> block
+  );
 }
 
 #endif

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -1,3 +1,4 @@
+#include <cassert>
 #include <poi/bytecode.h>
 #include <poi/error.h>
 #include <type_traits>
@@ -27,9 +28,6 @@ void Poi::Bytecode::relocate(std::ptrdiff_t offset) {
     case BytecodeType::EXIT: {
       break;
     }
-    case BytecodeType::MOVE: {
-      break;
-    }
     case BytecodeType::RETURN: {
       break;
     }
@@ -37,7 +35,7 @@ void Poi::Bytecode::relocate(std::ptrdiff_t offset) {
       break;
     }
     default: {
-      throw Error("relocate(...) is not implemented for '" + type_name + "'.");
+      assert(false);
     }
   }
 }
@@ -92,12 +90,6 @@ std::string Poi::Bytecode::show() const {
         " value=" + std::to_string(exit_args.value);
       break;
     }
-    case BytecodeType::MOVE: {
-      result +=
-        " destination=" + std::to_string(move_args.destination) +
-        " source=" + std::to_string(move_args.source);
-      break;
-    }
     case BytecodeType::RETURN: {
       result +=
         " value=" + std::to_string(return_args.value);
@@ -110,7 +102,7 @@ std::string Poi::Bytecode::show() const {
       break;
     }
     default: {
-      throw Error("show(...) is not implemented for '" + result + "'.");
+      assert(false);
     }
   }
   return result;

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -11,7 +11,7 @@ std::shared_ptr<Poi::IrBlock> Poi::compile_ast_to_ir(
   auto block = std::make_shared<IrBlock>();
   std::unordered_map<std::size_t, VariableInfo> environment;
   term->emit_ir(term, *block, 0, false, environment);
-  block->get_instructions()->push_back(
+  block->instructions->push_back(
     std::make_shared<IrExit>(0, std::static_pointer_cast<const Node>(term))
   );
   return block;

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -116,7 +116,7 @@ Poi::Value * Poi::interpret(
 ) {
   auto program = &(block.bytecode[0]);
 
-  std::size_t value_stack_size = start_stack_size;
+  std::size_t value_stack_size = 0;
   std::size_t value_stack_buffer_size = min_stack_buffer_size;
   auto value_stack = new Value * [value_stack_buffer_size];
   #ifndef NDEBUG
@@ -277,7 +277,7 @@ Poi::Value * Poi::interpret(
         auto target = value_stack[
           value_stack_size - 1 - bytecode.deref_fixpoint_args.fixpoint
         ]->fixpoint_members.target;
-        if (target == nullptr) {
+        if (!target) {
           throw_error(
             "Recursive reference evaluated before the knot has been tied.",
             program_counter,
@@ -312,11 +312,6 @@ Poi::Value * Poi::interpret(
         delete [] value_stack;
         delete [] call_stack;
         return result;
-      }
-      case BytecodeType::MOVE: {
-        value_stack[value_stack_size - 1 - bytecode.move_args.destination] =
-          value_stack[value_stack_size - 1 - bytecode.move_args.source];
-        break;
       }
       case BytecodeType::RETURN: {
         auto return_value = value_stack[
@@ -387,9 +382,7 @@ Poi::Value * Poi::interpret(
         continue;
       }
       default: {
-        throw Error(
-          "interpret(...) is not implemented for '" + bytecode.show() + "'."
-        );
+        assert(false);
       }
     }
     program_counter++;

--- a/src/optimizer.cpp
+++ b/src/optimizer.cpp
@@ -1,7 +1,478 @@
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
 #include <poi/optimizer.h>
+#include <unordered_map>
+#include <unordered_set>
 
-std::shared_ptr<Poi::IrBlock> Poi::optimize(
-  std::shared_ptr<Poi::IrBlock> block
+namespace Poi {
+  void reverse_pass_input(
+    std::uint16_t input_register,
+    std::unordered_set<std::uint16_t> &alive,
+    std::unordered_set<std::uint16_t> &last_read
+  ) {
+    if (alive.insert(input_register).second) {
+      last_read.insert(input_register);
+    }
+  }
+
+  void reverse_pass_output(
+    std::uint16_t output_register,
+    std::unordered_set<std::uint16_t> &alive
+  ) {
+    auto iter = alive.find(output_register);
+    if (iter != alive.end()) {
+      alive.erase(iter);
+    }
+  }
+
+  std::uint16_t forward_pass_read(
+    std::uint16_t old,
+    std::unordered_map<std::uint16_t, std::uint16_t> &old_to_new
+  ) {
+    return old_to_new.find(old)->second;
+  }
+
+  void forward_pass_elim_registers(
+    std::unordered_set<std::uint16_t> &free_registers,
+    std::unordered_map<std::uint16_t, std::uint16_t> &old_to_new,
+    std::unordered_map<std::uint16_t, std::uint16_t> &new_refcounts,
+    std::unordered_set<std::uint16_t> &registers
+  ) {
+    for (auto &old_reg : registers) {
+      auto new_reg = forward_pass_read(old_reg, old_to_new);
+      auto new_refcount = new_refcounts.find(new_reg);
+      --(new_refcount->second);
+      if (new_refcount->second == 0) {
+        free_registers.insert(new_reg);
+        new_refcounts.erase(new_refcount);
+      }
+      old_to_new.erase(old_reg);
+    }
+  }
+
+  std::uint16_t forward_pass_write(
+    std::uint16_t old,
+    std::uint16_t &total_registers,
+    std::unordered_set<std::uint16_t> &free_registers,
+    std::unordered_map<std::uint16_t, std::uint16_t> &old_to_new,
+    std::unordered_map<std::uint16_t, std::uint16_t> &new_refcounts
+  ) {
+    auto free_reg = free_registers.begin();
+    if (free_reg == free_registers.end()) {
+      auto reg = total_registers;
+      old_to_new.insert({ old, reg });
+      auto new_refcount = new_refcounts.find(reg);
+      if (new_refcount == new_refcounts.end()) {
+        new_refcounts.insert({ reg, 1 });
+      } else {
+        ++(new_refcount->second);
+      }
+      ++total_registers;
+      return reg;
+    } else {
+      auto reg = *free_reg;
+      free_registers.erase(free_reg);
+      old_to_new.insert({ old, reg });
+      auto new_refcount = new_refcounts.find(reg);
+      if (new_refcount == new_refcounts.end()) {
+        new_refcounts.insert({ reg, 1 });
+      } else {
+        ++(new_refcount->second);
+      }
+      return reg;
+    }
+  }
+
+  const std::shared_ptr<const IrBlock> allocate_registers(
+    const std::shared_ptr<const IrBlock> block
+  ) {
+    // Iterate through the instructions in reverse, marking the last time each
+    // register was read.
+    std::unordered_set<std::uint16_t> alive;
+    std::vector<std::unordered_set<std::uint16_t>> last_read(
+      block->instructions->size()
+    );
+    for (std::size_t i = block->instructions->size() - 1; true; --i) {
+      #ifndef NDEBUG
+        auto matched = false;
+      #endif
+
+      auto bc_begin_fixpoint = std::dynamic_pointer_cast<
+        const IrBeginFixpoint
+      >(block->instructions->at(i));
+      if (bc_begin_fixpoint) {
+        reverse_pass_output(bc_begin_fixpoint->destination, alive);
+        #ifndef NDEBUG
+          matched = true;
+        #endif
+      }
+
+      auto bc_call = std::dynamic_pointer_cast<
+        const IrCall
+      >(block->instructions->at(i));
+      if (bc_call) {
+        reverse_pass_output(bc_call->destination, alive);
+        reverse_pass_input(bc_call->function, alive, last_read[i]);
+        reverse_pass_input(bc_call->argument, alive, last_read[i]);
+        #ifndef NDEBUG
+          matched = true;
+        #endif
+      }
+
+      auto bc_create_function = std::dynamic_pointer_cast<
+        const IrCreateFunction
+      >(block->instructions->at(i));
+      if (bc_create_function) {
+        reverse_pass_output(bc_create_function->destination, alive);
+        for (auto &capture : *(bc_create_function->captures)) {
+          reverse_pass_input(capture, alive, last_read[i]);
+        }
+        #ifndef NDEBUG
+          matched = true;
+        #endif
+      }
+
+      auto bc_deref_fixpoint = std::dynamic_pointer_cast<
+        const IrDerefFixpoint
+      >(block->instructions->at(i));
+      if (bc_deref_fixpoint) {
+        reverse_pass_output(bc_deref_fixpoint->destination, alive);
+        reverse_pass_input(bc_deref_fixpoint->fixpoint, alive, last_read[i]);
+        #ifndef NDEBUG
+          matched = true;
+        #endif
+      }
+
+      auto bc_end_fixpoint = std::dynamic_pointer_cast<
+        const IrEndFixpoint
+      >(block->instructions->at(i));
+      if (bc_end_fixpoint) {
+        reverse_pass_output(bc_end_fixpoint->fixpoint, alive);
+        reverse_pass_input(bc_end_fixpoint->fixpoint, alive, last_read[i]);
+        reverse_pass_input(bc_end_fixpoint->target, alive, last_read[i]);
+        #ifndef NDEBUG
+          matched = true;
+        #endif
+      }
+
+      auto bc_exit = std::dynamic_pointer_cast<
+        const IrExit
+      >(block->instructions->at(i));
+      if (bc_exit) {
+        reverse_pass_input(bc_exit->value, alive, last_read[i]);
+        #ifndef NDEBUG
+          matched = true;
+        #endif
+      }
+
+      auto bc_move = std::dynamic_pointer_cast<
+        const IrMove
+      >(block->instructions->at(i));
+      if (bc_move) {
+        reverse_pass_output(bc_move->destination, alive);
+        reverse_pass_input(bc_move->source, alive, last_read[i]);
+        #ifndef NDEBUG
+          matched = true;
+        #endif
+      }
+
+      auto bc_return = std::dynamic_pointer_cast<
+        const IrReturn
+      >(block->instructions->at(i));
+      if (bc_return) {
+        reverse_pass_input(bc_return->value, alive, last_read[i]);
+        #ifndef NDEBUG
+          matched = true;
+        #endif
+      }
+
+      auto bc_tail_call = std::dynamic_pointer_cast<
+        const IrTailCall
+      >(block->instructions->at(i));
+      if (bc_tail_call) {
+        reverse_pass_input(bc_tail_call->function, alive, last_read[i]);
+        reverse_pass_input(bc_tail_call->argument, alive, last_read[i]);
+        #ifndef NDEBUG
+          matched = true;
+        #endif
+      }
+
+      assert(matched);
+      if (i == 0) {
+        break;
+      }
+    }
+
+    // Do a forward pass through the instructions to allocate the registers.
+    auto new_block = std::make_shared<IrBlock>();
+    std::unordered_map<std::uint16_t, std::uint16_t> old_to_new;
+    std::unordered_map<std::uint16_t, std::uint16_t> new_refcounts;
+    std::uint16_t total_registers = 0;
+    for (auto &reg : alive) {
+      old_to_new.insert({ reg, reg });
+      new_refcounts.insert({ reg, 1 });
+      if (total_registers <= reg) {
+        total_registers = reg + 1;
+      }
+    }
+    std::unordered_set<std::uint16_t> free_registers;
+    for (std::uint16_t i = 0; i < total_registers; ++i) {
+      if (alive.find(i) == alive.end()) {
+        free_registers.insert(i);
+      }
+    }
+    for (std::size_t i = 0; i < block->instructions->size(); ++i) {
+      #ifndef NDEBUG
+        auto matched = false;
+      #endif
+
+      auto bc_begin_fixpoint = std::dynamic_pointer_cast<
+        const IrBeginFixpoint
+      >(block->instructions->at(i));
+      if (bc_begin_fixpoint) {
+        forward_pass_elim_registers(
+          free_registers,
+          old_to_new,
+          new_refcounts,
+          last_read[i]
+        );
+        auto reg_destination = forward_pass_write(
+          bc_begin_fixpoint->destination,
+          total_registers,
+          free_registers,
+          old_to_new,
+          new_refcounts
+        );
+        new_block->instructions->push_back(
+          std::make_shared<IrBeginFixpoint>(
+            reg_destination,
+            bc_begin_fixpoint->node
+          )
+        );
+        #ifndef NDEBUG
+          matched = true;
+        #endif
+      }
+
+      auto bc_call = std::dynamic_pointer_cast<
+        const IrCall
+      >(block->instructions->at(i));
+      if (bc_call) {
+        auto reg_function = forward_pass_read(bc_call->function, old_to_new);
+        auto reg_argument = forward_pass_read(bc_call->argument, old_to_new);
+        forward_pass_elim_registers(
+          free_registers,
+          old_to_new,
+          new_refcounts,
+          last_read[i]
+        );
+        auto reg_destination = forward_pass_write(
+          bc_call->destination,
+          total_registers,
+          free_registers,
+          old_to_new,
+          new_refcounts
+        );
+        new_block->instructions->push_back(
+          std::make_shared<IrCall>(
+            reg_destination,
+            reg_function,
+            reg_argument,
+            bc_call->node
+          )
+        );
+        #ifndef NDEBUG
+          matched = true;
+        #endif
+      }
+
+      auto bc_create_function = std::dynamic_pointer_cast<
+        const IrCreateFunction
+      >(block->instructions->at(i));
+      if (bc_create_function) {
+        auto captures = std::make_shared<std::vector<std::uint16_t>>();
+        for (auto &capture : *(bc_create_function->captures)) {
+          captures->push_back(forward_pass_read(capture, old_to_new));
+        }
+        forward_pass_elim_registers(
+          free_registers,
+          old_to_new,
+          new_refcounts,
+          last_read[i]
+        );
+        auto reg_destination = forward_pass_write(
+          bc_create_function->destination,
+          total_registers,
+          free_registers,
+          old_to_new,
+          new_refcounts
+        );
+        new_block->instructions->push_back(
+          std::make_shared<IrCreateFunction>(
+            reg_destination,
+            optimize(bc_create_function->body),
+            captures,
+            bc_create_function->node
+          )
+        );
+        #ifndef NDEBUG
+          matched = true;
+        #endif
+      }
+
+      auto bc_deref_fixpoint = std::dynamic_pointer_cast<
+        const IrDerefFixpoint
+      >(block->instructions->at(i));
+      if (bc_deref_fixpoint) {
+        auto reg_fixpoint = forward_pass_read(
+          bc_deref_fixpoint->fixpoint,
+          old_to_new
+        );
+        forward_pass_elim_registers(
+          free_registers,
+          old_to_new,
+          new_refcounts,
+          last_read[i]
+        );
+        auto reg_destination = forward_pass_write(
+          bc_deref_fixpoint->destination,
+          total_registers,
+          free_registers,
+          old_to_new,
+          new_refcounts
+        );
+        new_block->instructions->push_back(
+          std::make_shared<IrDerefFixpoint>(
+            reg_destination,
+            reg_fixpoint,
+            bc_deref_fixpoint->node
+          )
+        );
+        #ifndef NDEBUG
+          matched = true;
+        #endif
+      }
+
+      auto bc_end_fixpoint = std::dynamic_pointer_cast<
+        const IrEndFixpoint
+      >(block->instructions->at(i));
+      if (bc_end_fixpoint) {
+        auto reg_fixpoint = forward_pass_read(
+          bc_end_fixpoint->fixpoint,
+          old_to_new
+        );
+        auto reg_target = forward_pass_read(
+          bc_end_fixpoint->target,
+          old_to_new
+        );
+        new_block->instructions->push_back(
+          std::make_shared<IrEndFixpoint>(
+            reg_fixpoint,
+            reg_target,
+            bc_end_fixpoint->node
+          )
+        );
+        #ifndef NDEBUG
+          matched = true;
+        #endif
+      }
+
+      auto bc_exit = std::dynamic_pointer_cast<
+        const IrExit
+      >(block->instructions->at(i));
+      if (bc_exit) {
+        auto reg_value = forward_pass_read(bc_exit->value, old_to_new);
+        forward_pass_elim_registers(
+          free_registers,
+          old_to_new,
+          new_refcounts,
+          last_read[i]
+        );
+        new_block->instructions->push_back(
+          std::make_shared<IrExit>(reg_value, bc_exit->node)
+        );
+        return new_block;
+      }
+
+      auto bc_move = std::dynamic_pointer_cast<
+        const IrMove
+      >(block->instructions->at(i));
+      if (bc_move) {
+        auto reg_source = forward_pass_read(bc_move->source, old_to_new);
+        auto previous_new_reg = old_to_new.find(bc_move->destination);
+        if (previous_new_reg != old_to_new.end()) {
+          auto new_refcount = new_refcounts.find(previous_new_reg->second);
+          --(new_refcount->second);
+          old_to_new.erase(bc_move->destination);
+        }
+        old_to_new.insert({ bc_move->destination, reg_source });
+        auto new_refcount = new_refcounts.find(reg_source);
+        if (new_refcount == new_refcounts.end()) {
+          new_refcounts.insert({ reg_source, 1 });
+        } else {
+          ++(new_refcount->second);
+        }
+        #ifndef NDEBUG
+          matched = true;
+        #endif
+      }
+
+      auto bc_return = std::dynamic_pointer_cast<
+        const IrReturn
+      >(block->instructions->at(i));
+      if (bc_return) {
+        auto reg_value = forward_pass_read(bc_return->value, old_to_new);
+        forward_pass_elim_registers(
+          free_registers,
+          old_to_new,
+          new_refcounts,
+          last_read[i]
+        );
+        new_block->instructions->push_back(
+          std::make_shared<IrReturn>(reg_value, bc_return->node)
+        );
+        return new_block;
+      }
+
+      auto bc_tail_call = std::dynamic_pointer_cast<
+        const IrTailCall
+      >(block->instructions->at(i));
+      if (bc_tail_call) {
+        auto reg_function = forward_pass_read(
+          bc_tail_call->function,
+          old_to_new
+        );
+        auto reg_argument = forward_pass_read(
+          bc_tail_call->argument,
+          old_to_new
+        );
+        forward_pass_elim_registers(
+          free_registers,
+          old_to_new,
+          new_refcounts,
+          last_read[i]
+        );
+        new_block->instructions->push_back(
+          std::make_shared<IrTailCall>(
+            reg_function,
+            reg_argument,
+            bc_tail_call->node
+          )
+        );
+        return new_block;
+      }
+
+      assert(matched);
+    }
+
+    return new_block;
+  }
+}
+
+const std::shared_ptr<const Poi::IrBlock> Poi::optimize(
+  const std::shared_ptr<const Poi::IrBlock> block
 ) {
-  return block;
+  // Perform register allocation.
+  return allocate_registers(block);
 }

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -1,3 +1,4 @@
+#include <cassert>
 #include <poi/error.h>
 #include <poi/value.h>
 #include <type_traits>
@@ -39,7 +40,7 @@ std::string Poi::Value::show(std::size_t depth) const {
       break;
     }
     default: {
-      throw Error("show(...) is not implemented for '" + result + "'.");
+      assert(false);
     }
   }
 

--- a/tests/application.json
+++ b/tests/application.json
@@ -1,6 +1,6 @@
 {
   "source": "(x -> y -> z -> y) (a -> a) (b -> b) (c -> c)",
-  "stdout": "FUNCTION body=16 frame_size=2 captures=[]\n",
+  "stdout": "FUNCTION body=14 frame_size=1 captures=[]\n",
   "stderr": "",
   "exit_code": 0
 }

--- a/tests/binding.json
+++ b/tests/binding.json
@@ -1,6 +1,6 @@
 {
   "source": "f = x -> x, g = y -> f y, g (z -> z)",
-  "stdout": "FUNCTION body=17 frame_size=2 captures=[]\n",
+  "stdout": "FUNCTION body=11 frame_size=1 captures=[]\n",
   "stderr": "",
   "exit_code": 0
 }

--- a/tests/comment.json
+++ b/tests/comment.json
@@ -1,6 +1,6 @@
 {
   "source": "# Comment 1\nx -> x # Comment 2\n# Comment 3",
-  "stdout": "FUNCTION body=2 frame_size=2 captures=[]\n",
+  "stdout": "FUNCTION body=2 frame_size=1 captures=[]\n",
   "stderr": "",
   "exit_code": 0
 }

--- a/tests/group.json
+++ b/tests/group.json
@@ -1,6 +1,6 @@
 {
   "source": "(x -> x (x x)) (a -> b -> a)",
-  "stdout": "FUNCTION body=9 frame_size=3 captures=[FUNCTION body=9 frame_size=3 captures=[FUNCTION body=11 frame_size=2 captures=[]]]\n",
+  "stdout": "FUNCTION body=6 frame_size=2 captures=[FUNCTION body=6 frame_size=2 captures=[FUNCTION body=7 frame_size=1 captures=[]]]\n",
   "stderr": "",
   "exit_code": 0
 }

--- a/tests/id.json
+++ b/tests/id.json
@@ -1,6 +1,6 @@
 {
   "source": "x -> x",
-  "stdout": "FUNCTION body=2 frame_size=2 captures=[]\n",
+  "stdout": "FUNCTION body=2 frame_size=1 captures=[]\n",
   "stderr": "",
   "exit_code": 0
 }

--- a/tests/line_continuation.json
+++ b/tests/line_continuation.json
@@ -1,6 +1,6 @@
 {
   "source": "x -> \\\nx",
-  "stdout": "FUNCTION body=2 frame_size=2 captures=[]\n",
+  "stdout": "FUNCTION body=2 frame_size=1 captures=[]\n",
   "stderr": "",
   "exit_code": 0
 }

--- a/tests/unicode.json
+++ b/tests/unicode.json
@@ -1,6 +1,6 @@
 {
   "source": "🍆 -> 🍆",
-  "stdout": "FUNCTION body=2 frame_size=2 captures=[]\n",
+  "stdout": "FUNCTION body=2 frame_size=1 captures=[]\n",
   "stderr": "",
   "exit_code": 0
 }


### PR DESCRIPTION
Implement an optimal linear-time register allocator based on linear scanning. This is possible because we have an unbounded number of registers available.

Consider the following benchmark program:

```
zero = f -> x -> x
succ = n -> f -> x -> f (n f x)
add = m -> n -> f -> x -> m f (n f x)
mul = m -> n -> f -> m (n f)
exp = m -> n -> n m
one = succ zero
two = add one one
four = mul two two
six = add four two
sixteen = mul four four
big = exp sixteen six
big (x -> x) (x -> x)
```

Without the register allocator, this takes ~11.960 seconds on my laptop. With the register allocator, it takes ~9.962 seconds. That's a **16.7%** speedup.

## Bytecode without the register allocator

```
0 BEGIN_FIXPOINT destination=1
1 CREATE_FUNCTION destination=2 body=74 frame_size=2 captures=[]
2 END_FIXPOINT fixpoint=1 target=2
3 BEGIN_FIXPOINT destination=4
4 CREATE_FUNCTION destination=5 body=85 frame_size=2 captures=[]
5 END_FIXPOINT fixpoint=4 target=5
6 BEGIN_FIXPOINT destination=7
7 CREATE_FUNCTION destination=8 body=100 frame_size=2 captures=[]
8 END_FIXPOINT fixpoint=7 target=8
9 BEGIN_FIXPOINT destination=10
10 CREATE_FUNCTION destination=11 body=109 frame_size=2 captures=[]
11 END_FIXPOINT fixpoint=10 target=11
12 BEGIN_FIXPOINT destination=13
13 CREATE_FUNCTION destination=14 body=114 frame_size=2 captures=[]
14 END_FIXPOINT fixpoint=13 target=14
15 BEGIN_FIXPOINT destination=16
16 MOVE destination=18 source=5
17 MOVE destination=19 source=2
18 CALL destination=17 function=18 argument=19
19 END_FIXPOINT fixpoint=16 target=17
20 BEGIN_FIXPOINT destination=38
21 MOVE destination=41 source=8
22 MOVE destination=42 source=17
23 CALL destination=40 function=41 argument=42
24 MOVE destination=83 source=17
25 CALL destination=39 function=40 argument=83
26 END_FIXPOINT fixpoint=38 target=39
27 BEGIN_FIXPOINT destination=124
28 MOVE destination=127 source=11
29 MOVE destination=128 source=39
30 CALL destination=126 function=127 argument=128
31 MOVE destination=255 source=39
32 CALL destination=125 function=126 argument=255
33 END_FIXPOINT fixpoint=124 target=125
34 BEGIN_FIXPOINT destination=382
35 MOVE destination=385 source=8
36 MOVE destination=386 source=125
37 CALL destination=384 function=385 argument=386
38 MOVE destination=771 source=39
39 CALL destination=383 function=384 argument=771
40 END_FIXPOINT fixpoint=382 target=383
41 BEGIN_FIXPOINT destination=1156
42 MOVE destination=1159 source=11
43 MOVE destination=1160 source=125
44 CALL destination=1158 function=1159 argument=1160
45 MOVE destination=2319 source=125
46 CALL destination=1157 function=1158 argument=2319
47 END_FIXPOINT fixpoint=1156 target=1157
48 BEGIN_FIXPOINT destination=3478
49 MOVE destination=3481 source=14
50 MOVE destination=3482 source=1157
51 CALL destination=3480 function=3481 argument=3482
52 MOVE destination=6963 source=383
53 CALL destination=3479 function=3480 argument=6963
54 END_FIXPOINT fixpoint=3478 target=3479
55 MOVE destination=10445 source=3479
56 CREATE_FUNCTION destination=10446 body=116 frame_size=2 captures=[]
57 CALL destination=10444 function=10445 argument=10446
58 CREATE_FUNCTION destination=20891 body=118 frame_size=2 captures=[]
59 CALL destination=10443 function=10444 argument=20891
60 MOVE destination=3477 source=10443
61 MOVE destination=1155 source=3477
62 MOVE destination=381 source=1155
63 MOVE destination=123 source=381
64 MOVE destination=37 source=123
65 MOVE destination=15 source=37
66 MOVE destination=12 source=15
67 MOVE destination=9 source=12
68 MOVE destination=6 source=9
69 MOVE destination=3 source=6
70 MOVE destination=0 source=3
71 EXIT value=0
72 MOVE destination=1 source=0
73 RETURN value=1
74 CREATE_FUNCTION destination=1 body=72 frame_size=2 captures=[]
75 RETURN value=1
76 MOVE destination=4 source=1
77 MOVE destination=7 source=2
78 MOVE destination=8 source=1
79 CALL destination=6 function=7 argument=8
80 MOVE destination=15 source=0
81 CALL destination=5 function=6 argument=15
82 TAIL_CALL function=4 argument=5
83 CREATE_FUNCTION destination=2 body=76 frame_size=16 captures=[0, 1]
84 RETURN value=2
85 CREATE_FUNCTION destination=1 body=83 frame_size=3 captures=[0]
86 RETURN value=1
87 MOVE destination=6 source=3
88 MOVE destination=7 source=1
89 CALL destination=5 function=6 argument=7
90 MOVE destination=15 source=2
91 MOVE destination=16 source=1
92 CALL destination=14 function=15 argument=16
93 MOVE destination=31 source=0
94 CALL destination=13 function=14 argument=31
95 TAIL_CALL function=5 argument=13
96 CREATE_FUNCTION destination=3 body=87 frame_size=32 captures=[0, 2, 1]
97 RETURN value=3
98 CREATE_FUNCTION destination=2 body=96 frame_size=4 captures=[1, 0]
99 RETURN value=2
100 CREATE_FUNCTION destination=1 body=98 frame_size=3 captures=[0]
101 RETURN value=1
102 MOVE destination=4 source=1
103 MOVE destination=6 source=2
104 MOVE destination=7 source=0
105 CALL destination=5 function=6 argument=7
106 TAIL_CALL function=4 argument=5
107 CREATE_FUNCTION destination=2 body=102 frame_size=8 captures=[1, 0]
108 RETURN value=2
109 CREATE_FUNCTION destination=1 body=107 frame_size=3 captures=[0]
110 RETURN value=1
111 MOVE destination=3 source=0
112 MOVE destination=4 source=1
113 TAIL_CALL function=3 argument=4
114 CREATE_FUNCTION destination=1 body=111 frame_size=5 captures=[0]
115 RETURN value=1
116 MOVE destination=1 source=0
117 RETURN value=1
118 MOVE destination=1 source=0
119 RETURN value=1
```

## Bytecode with the register allocator

```
0 BEGIN_FIXPOINT destination=0
1 CREATE_FUNCTION destination=1 body=44 frame_size=1 captures=[]
2 END_FIXPOINT fixpoint=0 target=1
3 BEGIN_FIXPOINT destination=2
4 CREATE_FUNCTION destination=3 body=51 frame_size=1 captures=[]
5 END_FIXPOINT fixpoint=2 target=3
6 BEGIN_FIXPOINT destination=4
7 CREATE_FUNCTION destination=5 body=61 frame_size=1 captures=[]
8 END_FIXPOINT fixpoint=4 target=5
9 BEGIN_FIXPOINT destination=6
10 CREATE_FUNCTION destination=7 body=67 frame_size=1 captures=[]
11 END_FIXPOINT fixpoint=6 target=7
12 BEGIN_FIXPOINT destination=8
13 CREATE_FUNCTION destination=9 body=70 frame_size=1 captures=[]
14 END_FIXPOINT fixpoint=8 target=9
15 BEGIN_FIXPOINT destination=10
16 CALL destination=11 function=3 argument=1
17 END_FIXPOINT fixpoint=10 target=11
18 BEGIN_FIXPOINT destination=12
19 CALL destination=13 function=5 argument=11
20 CALL destination=13 function=13 argument=11
21 END_FIXPOINT fixpoint=12 target=13
22 BEGIN_FIXPOINT destination=14
23 CALL destination=15 function=7 argument=13
24 CALL destination=15 function=15 argument=13
25 END_FIXPOINT fixpoint=14 target=15
26 BEGIN_FIXPOINT destination=16
27 CALL destination=17 function=5 argument=15
28 CALL destination=17 function=17 argument=13
29 END_FIXPOINT fixpoint=16 target=17
30 BEGIN_FIXPOINT destination=18
31 CALL destination=19 function=7 argument=15
32 CALL destination=19 function=19 argument=15
33 END_FIXPOINT fixpoint=18 target=19
34 BEGIN_FIXPOINT destination=20
35 CALL destination=21 function=9 argument=19
36 CALL destination=21 function=21 argument=17
37 END_FIXPOINT fixpoint=20 target=21
38 CREATE_FUNCTION destination=22 body=72 frame_size=1 captures=[]
39 CALL destination=22 function=21 argument=22
40 CREATE_FUNCTION destination=23 body=73 frame_size=1 captures=[]
41 CALL destination=22 function=22 argument=23
42 EXIT value=22
43 RETURN value=0
44 CREATE_FUNCTION destination=0 body=43 frame_size=1 captures=[]
45 RETURN value=0
46 CALL destination=4 function=2 argument=1
47 CALL destination=4 function=4 argument=0
48 TAIL_CALL function=1 argument=4
49 CREATE_FUNCTION destination=0 body=46 frame_size=5 captures=[0, 1]
50 RETURN value=0
51 CREATE_FUNCTION destination=0 body=49 frame_size=2 captures=[0]
52 RETURN value=0
53 CALL destination=5 function=3 argument=1
54 CALL destination=6 function=2 argument=1
55 CALL destination=6 function=6 argument=0
56 TAIL_CALL function=5 argument=6
57 CREATE_FUNCTION destination=0 body=53 frame_size=7 captures=[0, 2, 1]
58 RETURN value=0
59 CREATE_FUNCTION destination=1 body=57 frame_size=3 captures=[1, 0]
60 RETURN value=1
61 CREATE_FUNCTION destination=0 body=59 frame_size=2 captures=[0]
62 RETURN value=0
63 CALL destination=4 function=2 argument=0
64 TAIL_CALL function=1 argument=4
65 CREATE_FUNCTION destination=1 body=63 frame_size=5 captures=[1, 0]
66 RETURN value=1
67 CREATE_FUNCTION destination=0 body=65 frame_size=2 captures=[0]
68 RETURN value=0
69 TAIL_CALL function=0 argument=1
70 CREATE_FUNCTION destination=0 body=69 frame_size=2 captures=[0]
71 RETURN value=0
72 RETURN value=0
73 RETURN value=0
```

**Status:** Ready

**Fixes:** N/A
